### PR TITLE
prevent creation of default user in noauth profile too

### DIFF
--- a/src/main/resources/application-noauth.yml
+++ b/src/main/resources/application-noauth.yml
@@ -1,4 +1,6 @@
 spring:
   autoconfigure:
     exclude:
+      # Disable UserDetailsServiceAutoConfiguration to prevent auto-creation of a test user
+      - org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration
       - org.springframework.boot.autoconfigure.security.saml2.Saml2RelyingPartyAutoConfiguration


### PR DESCRIPTION
You may have noticed this during startup when using the noauth profile:

```
Using generated security password: ce94e883-c627-484b-a022-f613ce822861

This generated password is for development use only. Your security configuration must be updated before running your application in production.
```

It's not really harmful, but not useful either