### PR TITLE
[GLT-3687] added Project Details page

### DIFF
--- a/src/main/java/ca/on/oicr/gsi/dimsum/CaseLoader.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/CaseLoader.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -157,6 +158,8 @@ public class CaseLoader {
             .timepoint(parseString(json, "timepoint")).groupId(parseString(json, "group_id"))
             .targetedSequencing(parseString(json, "targeted_sequencing"))
             .createdDate(parseSampleCreatedDate(json)).run(parseRun(json))
+            .volume(parseDecimal(json, "volume", false))
+            .concentration(parseDecimal(json, "concentration", false))
             .qcPassed(parseQcPassed(json, "qc_state")).qcReason(parseString(json, "qc_reason"))
             .qcUser(parseString(json, "qc_user")).qcDate(parseDate(json, "qc_date"))
             .dataReviewPassed(parseDataReviewPassed(json, "data_review_state"))
@@ -320,6 +323,12 @@ public class CaseLoader {
     } else {
       return node.asBoolean();
     }
+  }
+
+  private static BigDecimal parseDecimal(JsonNode json, String fieldName, boolean required)
+      throws DataParseException {
+    String stringValue = parseString(json, fieldName, required);
+    return stringValue == null ? null : new BigDecimal(stringValue);
   }
 
   private static List<RequisitionQc> parseRequisitionQcs(JsonNode json, String fieldName)

--- a/src/main/java/ca/on/oicr/gsi/dimsum/controller/NotFoundException.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/controller/NotFoundException.java
@@ -1,0 +1,21 @@
+package ca.on.oicr.gsi.dimsum.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Exception to throw when the client has requested a resource that doesn't exist, generally based
+ * on requested URL. Will result in a HTTP 404 not found error
+ */
+public class NotFoundException extends ResponseStatusException {
+
+  /**
+   * Create a new BadRequestException indicating client error
+   * 
+   * @param reason explanation to return to the client
+   */
+  public NotFoundException(String reason) {
+    super(HttpStatus.NOT_FOUND, reason);
+  }
+
+}

--- a/src/main/java/ca/on/oicr/gsi/dimsum/controller/mvc/MvcUtils.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/controller/mvc/MvcUtils.java
@@ -37,22 +37,28 @@ public class MvcUtils {
     return query.getDescending() == null ? false : query.getDescending();
   }
 
-  public static List<CaseFilter> parseCaseFilters(DataQuery query) {
+  public static CaseFilter parseBaseFilter(DataQuery query) {
+    if (query.getBaseFilter() == null) {
+      return null;
+    }
+    return parseCaseFilter(query.getBaseFilter());
+  }
 
+  public static List<CaseFilter> parseCaseFilters(DataQuery query) {
     List<KeyValuePair> queryFilters = query.getFilters();
     if (queryFilters == null || queryFilters.isEmpty()) {
       return null;
     }
-    List<CaseFilter> filters = new ArrayList<>();
-    for (KeyValuePair pair : queryFilters) {
-      try {
-        CaseFilterKey key = CaseFilterKey.valueOf(pair.getKey());
-        filters.add(new CaseFilter(key, pair.getValue()));
-      } catch (IllegalArgumentException e) {
-        throw new BadRequestException(String.format("Invalid filter key: %s", pair.getKey()));
-      }
+    return queryFilters.stream().map(MvcUtils::parseCaseFilter).toList();
+  }
+
+  private static CaseFilter parseCaseFilter(KeyValuePair pair) {
+    try {
+      CaseFilterKey key = CaseFilterKey.valueOf(pair.getKey());
+      return new CaseFilter(key, pair.getValue());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(String.format("Invalid filter key: %s", pair.getKey()));
     }
-    return filters;
   }
 
 }

--- a/src/main/java/ca/on/oicr/gsi/dimsum/controller/mvc/ProjectController.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/controller/mvc/ProjectController.java
@@ -1,0 +1,36 @@
+package ca.on.oicr.gsi.dimsum.controller.mvc;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import ca.on.oicr.gsi.dimsum.controller.NotFoundException;
+import ca.on.oicr.gsi.dimsum.data.Case;
+import ca.on.oicr.gsi.dimsum.service.CaseService;
+import ca.on.oicr.gsi.dimsum.service.filtering.CaseFilter;
+import ca.on.oicr.gsi.dimsum.service.filtering.CaseFilterKey;
+
+@Controller
+@RequestMapping("/projects")
+public class ProjectController {
+
+  @Autowired
+  private CaseService caseService;
+
+  @GetMapping("/{projectName}")
+  public String getProjectDetailsPage(@PathVariable String projectName, ModelMap model) {
+    List<Case> cases = caseService.getCases(new CaseFilter(CaseFilterKey.PROJECT, projectName));
+    if (cases.isEmpty()) {
+      throw new NotFoundException(String.format("No data found for project: %s", projectName));
+    }
+
+    model.put("title", String.format("%s Project Details", projectName));
+    model.put("detailType", CaseFilterKey.PROJECT.name());
+    model.put("detailValue", projectName);
+    return "detail";
+  }
+
+}

--- a/src/main/java/ca/on/oicr/gsi/dimsum/controller/rest/CaseRestController.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/controller/rest/CaseRestController.java
@@ -27,9 +27,10 @@ public class CaseRestController {
     validateDataQuery(query);
     CaseSort sort = parseSort(query, CaseSort::getByLabel);
     boolean descending = parseDescending(query);
+    CaseFilter baseFilter = parseBaseFilter(query);
     List<CaseFilter> filters = parseCaseFilters(query);
     return caseService.getCases(query.getPageSize(), query.getPageNumber(), sort, descending,
-        filters);
+        baseFilter, filters);
   }
 
 

--- a/src/main/java/ca/on/oicr/gsi/dimsum/controller/rest/RequisitionRestController.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/controller/rest/RequisitionRestController.java
@@ -26,9 +26,10 @@ public class RequisitionRestController {
     validateDataQuery(query);
     RequisitionSort sort = parseSort(query, RequisitionSort::getByLabel);
     boolean descending = parseDescending(query);
+    CaseFilter baseFilter = parseBaseFilter(query);
     List<CaseFilter> filters = parseCaseFilters(query);
     return caseService.getRequisitions(query.getPageSize(), query.getPageNumber(), sort, descending,
-        filters);
+        baseFilter, filters);
   }
 
 

--- a/src/main/java/ca/on/oicr/gsi/dimsum/controller/rest/SampleRestController.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/controller/rest/SampleRestController.java
@@ -51,15 +51,17 @@ public class SampleRestController {
   @FunctionalInterface
   private interface SampleGetter {
     public TableData<Sample> get(int pageSize, int pageNumber, SampleSort sort, boolean descending,
-        Collection<CaseFilter> filters);
+        CaseFilter baseFilter, Collection<CaseFilter> filters);
   }
 
   private TableData<Sample> getSamples(DataQuery query, SampleGetter getter) {
     validateDataQuery(query);
     SampleSort sort = parseSort(query, SampleSort::getByLabel);
     boolean descending = parseDescending(query);
+    CaseFilter baseFilter = parseBaseFilter(query);
     List<CaseFilter> filters = parseCaseFilters(query);
-    return getter.get(query.getPageSize(), query.getPageNumber(), sort, descending, filters);
+    return getter.get(query.getPageSize(), query.getPageNumber(), sort, descending, baseFilter,
+        filters);
   }
 
 }

--- a/src/main/java/ca/on/oicr/gsi/dimsum/controller/rest/request/DataQuery.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/controller/rest/request/DataQuery.java
@@ -6,6 +6,7 @@ public class DataQuery {
 
   private int pageNumber;
   private int pageSize;
+  private KeyValuePair baseFilter;
   private List<KeyValuePair> filters;
   private String sortColumn;
   private Boolean descending;
@@ -24,6 +25,14 @@ public class DataQuery {
 
   public void setPageSize(int pageSize) {
     this.pageSize = pageSize;
+  }
+
+  public KeyValuePair getBaseFilter() {
+    return baseFilter;
+  }
+
+  public void setBaseFilter(KeyValuePair baseFilter) {
+    this.baseFilter = baseFilter;
   }
 
   public List<KeyValuePair> getFilters() {

--- a/src/main/java/ca/on/oicr/gsi/dimsum/data/Case.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/data/Case.java
@@ -47,7 +47,7 @@ public class Case {
     this.latestActivityDate = Stream
         .of(receipts.stream().map(Sample::getLatestActivityDate),
             tests.stream().map(Test::getLatestActivityDate),
-            requisitions.stream().map(Requisition::getLatestActivity))
+            requisitions.stream().map(Requisition::getLatestActivityDate))
         .flatMap(Function.identity()).filter(Objects::nonNull).max(LocalDate::compareTo)
         .orElse(null);
   }

--- a/src/main/java/ca/on/oicr/gsi/dimsum/data/Requisition.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/data/Requisition.java
@@ -63,7 +63,7 @@ public class Requisition {
     return finalReports;
   }
 
-  public LocalDate getLatestActivity() {
+  public LocalDate getLatestActivityDate() {
     return latestActivityDate;
   }
 

--- a/src/main/java/ca/on/oicr/gsi/dimsum/data/Sample.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/data/Sample.java
@@ -1,7 +1,7 @@
 package ca.on.oicr.gsi.dimsum.data;
 
 import static java.util.Objects.requireNonNull;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -19,6 +19,8 @@ public class Sample {
   private final String groupId;
   private final String targetedSequencing;
   private final LocalDate createdDate;
+  private final BigDecimal volume;
+  private final BigDecimal concentration;
   private final Run run;
   private final Boolean qcPassed;
   private final String qcReason;
@@ -38,6 +40,8 @@ public class Sample {
     this.groupId = builder.groupId;
     this.targetedSequencing = builder.targetedSequencing;
     this.createdDate = requireNonNull(builder.createdDate);
+    this.volume = builder.volume;
+    this.concentration = builder.concentration;
     this.run = builder.run;
     this.qcPassed = builder.qcPassed;
     this.qcReason = builder.qcReason;
@@ -80,6 +84,14 @@ public class Sample {
 
   public LocalDate getCreatedDate() {
     return createdDate;
+  }
+
+  public BigDecimal getVolume() {
+    return volume;
+  }
+
+  public BigDecimal getConcentration() {
+    return concentration;
   }
 
   public Run getRun() {
@@ -145,6 +157,8 @@ public class Sample {
     private String groupId;
     private String targetedSequencing;
     private LocalDate createdDate;
+    private BigDecimal volume;
+    private BigDecimal concentration;
     private Run run;
     private Boolean qcPassed;
     private String qcReason;
@@ -191,6 +205,16 @@ public class Sample {
 
     public Builder createdDate(LocalDate createdDate) {
       this.createdDate = createdDate;
+      return this;
+    }
+
+    public Builder volume(BigDecimal volume) {
+      this.volume = volume;
+      return this;
+    }
+
+    public Builder concentration(BigDecimal concentration) {
+      this.concentration = concentration;
       return this;
     }
 

--- a/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/RequisitionSort.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/RequisitionSort.java
@@ -9,7 +9,11 @@ import ca.on.oicr.gsi.dimsum.data.Requisition;
 
 public enum RequisitionSort {
 
-  NAME("Name", Comparator.comparing(Requisition::getName));
+  // @formatter:off
+  NAME("Requisition", Comparator.comparing(Requisition::getName)),
+  LATEST_ACTIVITY("Latest Activity", Comparator.comparing(
+      Requisition::getLatestActivityDate, Comparator.nullsFirst(Comparator.naturalOrder())));
+  // @formatter:off
 
   private static final Map<String, RequisitionSort> map = Stream.of(RequisitionSort.values())
       .collect(Collectors.toMap(RequisitionSort::getLabel, Function.identity()));

--- a/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/SampleSort.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/SampleSort.java
@@ -9,7 +9,10 @@ import ca.on.oicr.gsi.dimsum.data.Sample;
 
 public enum SampleSort {
 
-  NAME("Name", Comparator.comparing(Sample::getName));
+  // @formatter:off
+  NAME("Name", Comparator.comparing(Sample::getName)),
+  LATEST_ACTIVITY("Latest Activity", Comparator.comparing(Sample::getLatestActivityDate));
+  // @formatter:on
 
   private static final Map<String, SampleSort> map = Stream.of(SampleSort.values())
       .collect(Collectors.toMap(SampleSort::getLabel, Function.identity()));

--- a/src/main/resources/static/css/output.css
+++ b/src/main/resources/static/css/output.css
@@ -548,37 +548,28 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-bottom: 5rem;
 }
 
-.mx-2{
-  margin-left: 0.5rem;
-  margin-right: 0.5rem;
+.mt-8{
+  margin-top: 2rem;
 }
 
 .mt-4{
   margin-top: 1rem;
 }
 
-.mt-8{
-  margin-top: 2rem;
-}
-
 .mt-2{
   margin-top: 0.5rem;
-}
-
-.ml-2{
-  margin-left: 0.5rem;
 }
 
 .mr-2{
   margin-right: 0.5rem;
 }
 
-.inline-block{
-  display: inline-block;
+.ml-2{
+  margin-left: 0.5rem;
 }
 
-.inline{
-  display: inline;
+.inline-block{
+  display: inline-block;
 }
 
 .flex{
@@ -619,12 +610,12 @@ Ensure the default browser behavior of the `hidden` attribute.
   width: 1rem;
 }
 
-.w-0{
-  width: 0px;
-}
-
 .max-w-lg{
   max-width: 32rem;
+}
+
+.max-w-none{
+  max-width: none;
 }
 
 .flex-auto{
@@ -641,10 +632,6 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .grow{
   flex-grow: 1;
-}
-
-.basis-0{
-  flex-basis: 0px;
 }
 
 .border-separate{

--- a/src/main/resources/templates/detail.html
+++ b/src/main/resources/templates/detail.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  layout:decorate="~{layout}">
+
+<head>
+  <meta charset="UTF-8" />
+  <title th:text="${title}">Details</title>
+</head>
+
+<body>
+  <div layout:fragment="content">
+
+    <h1 class="text-green-200 font-sarabun font-light font text-32" th:text="${title}">Details</h1>
+    <div id="casesTableContainer" th:data-detail-type="${detailType}" th:data-detail-value="${detailValue}"></div>
+
+    <h2 class="text-green-200 font-sarabun font-light font text-24 mt-8">Receipts</h2>
+    <div id="receiptsTableContainer" th:data-detail-type="${detailType}" th:data-detail-value="${detailValue}"></div>
+
+    <h2 class="text-green-200 font-sarabun font-light font text-24 mt-8">Extractions</h2>
+    <div id="extractionsTableContainer" th:data-detail-type="${detailType}" th:data-detail-value="${detailValue}"></div>
+
+    <h2 class="text-green-200 font-sarabun font-light font text-24 mt-8">Library Preparations</h2>
+    <div id="libraryPreparationsTableContainer" th:data-detail-type="${detailType}"
+      th:data-detail-value="${detailValue}"></div>
+
+    <h2 class="text-green-200 font-sarabun font-light font text-24 mt-8">Library Qualifications</h2>
+    <div id="libraryQualificationsTableContainer" th:data-detail-type="${detailType}"
+      th:data-detail-value="${detailValue}"></div>
+
+    <h2 class="text-green-200 font-sarabun font-light font text-24 mt-8">Full Depth Sequencings</h2>
+    <div id="fullDepthSequencingsTableContainer" th:data-detail-type="${detailType}"
+      th:data-detail-value="${detailValue}"></div>
+
+    <h2 class="text-green-200 font-sarabun font-light font text-24 mt-8">Informatics Reviews</h2>
+    <div id="informaticsReviewsTableContainer" th:data-detail-type="${detailType}"
+      th:data-detail-value="${detailValue}"></div>
+
+    <h2 class="text-green-200 font-sarabun font-light font text-24 mt-8">Draft Reports</h2>
+    <div id="draftReportsTableContainer" th:data-detail-type="${detailType}" th:data-detail-value="${detailValue}">
+    </div>
+
+    <h2 class="text-green-200 font-sarabun font-light font text-24 mt-8">Final Reports</h2>
+    <div id="finalReportsTableContainer" th:data-detail-type="${detailType}" th:data-detail-value="${detailValue}">
+    </div>
+
+    <script src="/js/details.js"></script>
+
+  </div>
+</body>
+
+</html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -21,7 +21,7 @@
   <div id="header">
     <nav class="flex items-end m-4 border-b-2 border-grey-200">
       <div class="grow">
-        <div class="flex shrink"><a href="."><img th:src="@{/img/dimsum_logo.svg}" class="w-32" /></a></div>
+        <div class="flex shrink"><a href="/"><img th:src="@{/img/dimsum_logo.svg}" class="w-32" /></a></div>
       </div>
       <div class="flex grow justify-center text-green-200 font-sarabun font-light font text-24 cursor-default"
         th:text="${instanceName}"></div>

--- a/src/test/java/ca/on/oicr/gsi/dimsum/service/CaseServiceTest.java
+++ b/src/test/java/ca/on/oicr/gsi/dimsum/service/CaseServiceTest.java
@@ -36,7 +36,7 @@ public class CaseServiceTest {
 
   @org.junit.jupiter.api.Test
   public void testGetCases() {
-    TableData<Case> data = sut.getCases(10, 1, CaseSort.LAST_ACTIVITY, true, null);
+    TableData<Case> data = sut.getCases(10, 1, CaseSort.LAST_ACTIVITY, true, null, null);
     assertNotNull(data);
     assertEquals(2, data.getTotalCount());
     assertEquals(2, data.getFilteredCount());
@@ -46,7 +46,7 @@ public class CaseServiceTest {
 
   @org.junit.jupiter.api.Test
   public void testGetReceipts() {
-    TableData<Sample> data = sut.getReceipts(10, 1, SampleSort.NAME, true, null);
+    TableData<Sample> data = sut.getReceipts(10, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1N-A1", "1N-A2", "2N-A1", "2N-A2");
   }
 
@@ -54,13 +54,13 @@ public class CaseServiceTest {
   public void testGetReceiptsDistinct() {
     // Add duplicates and ensure they get removed from results
     addCase(caseData, 1);
-    TableData<Sample> data = sut.getReceipts(10, 1, SampleSort.NAME, true, null);
+    TableData<Sample> data = sut.getReceipts(10, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1N-A1", "1N-A2", "2N-A1", "2N-A2");
   }
 
   @org.junit.jupiter.api.Test
   public void testGetExtractions() {
-    TableData<Sample> data = sut.getExtractions(20, 1, SampleSort.NAME, true, null);
+    TableData<Sample> data = sut.getExtractions(20, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1A-B1", "1A-B2", "1B-B1", "1B-B2", "2A-B1", "2A-B2", "2B-B1",
         "2B-B2");
   }
@@ -69,28 +69,28 @@ public class CaseServiceTest {
   public void testGetExtractionsDistinct() {
     // Add duplicates and ensure they get removed from results
     addCase(caseData, 1);
-    TableData<Sample> data = sut.getExtractions(20, 1, SampleSort.NAME, true, null);
+    TableData<Sample> data = sut.getExtractions(20, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1A-B1", "1A-B2", "1B-B1", "1B-B2", "2A-B1", "2A-B2", "2B-B1",
         "2B-B2");
   }
 
   @org.junit.jupiter.api.Test
   public void testGetLibraryPreparations() {
-    TableData<Sample> data = sut.getLibraryPreparations(20, 1, SampleSort.NAME, true, null);
+    TableData<Sample> data = sut.getLibraryPreparations(20, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1A-C1", "1A-C2", "1B-C1", "1B-C2", "2A-C1", "2A-C2", "2B-C1",
         "2B-C2");
   }
 
   @org.junit.jupiter.api.Test
   public void testGetLibraryQualifications() {
-    TableData<Sample> data = sut.getLibraryQualifications(20, 1, SampleSort.NAME, true, null);
+    TableData<Sample> data = sut.getLibraryQualifications(20, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1A-D1", "1A-D2", "1B-D1", "1B-D2", "2A-D1", "2A-D2", "2B-D1",
         "2B-D2");
   }
 
   @org.junit.jupiter.api.Test
   public void testGetFullDepthSequencings() {
-    TableData<Sample> data = sut.getFullDepthSequencings(20, 1, SampleSort.NAME, true, null);
+    TableData<Sample> data = sut.getFullDepthSequencings(20, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1A-E1", "1A-E2", "1B-E1", "1B-E2", "2A-E1", "2A-E2", "2B-E1",
         "2B-E2");
   }
@@ -108,7 +108,8 @@ public class CaseServiceTest {
 
   @org.junit.jupiter.api.Test
   public void testGetRequisitions() {
-    TableData<Requisition> data = sut.getRequisitions(20, 1, RequisitionSort.NAME, true, null);
+    TableData<Requisition> data =
+        sut.getRequisitions(20, 1, RequisitionSort.NAME, true, null, null);
     assertContainsRequisitions(data, "REQ_1-1", "REQ_1-2", "REQ_2-1", "REQ_2-2");
   }
 
@@ -116,7 +117,8 @@ public class CaseServiceTest {
   public void testGetRequisitionsDistinct() {
     // Add duplicates and ensure they get removed from results
     addCase(caseData, 1);
-    TableData<Requisition> data = sut.getRequisitions(20, 1, RequisitionSort.NAME, true, null);
+    TableData<Requisition> data =
+        sut.getRequisitions(20, 1, RequisitionSort.NAME, true, null, null);
     assertContainsRequisitions(data, "REQ_1-1", "REQ_1-2", "REQ_2-1", "REQ_2-2");
   }
 

--- a/ts/data/qc-status.ts
+++ b/ts/data/qc-status.ts
@@ -1,0 +1,61 @@
+import { CellStatus } from "../util/html-utils";
+
+type QcStatusKey =
+  | "construction"
+  | "analysis"
+  | "qc"
+  | "dataReview"
+  | "passed"
+  | "failed"
+  | "topUp";
+
+export interface QcStatus {
+  label: string;
+  icon: string;
+  qcComplete: boolean;
+  cellStatus?: CellStatus;
+}
+
+export const qcStatuses: Record<QcStatusKey, QcStatus> = {
+  construction: {
+    label: "Pending work",
+    icon: "road-barrier",
+    qcComplete: false,
+    cellStatus: "warning",
+  },
+  analysis: {
+    label: "Pending analysis",
+    icon: "hourglass",
+    qcComplete: false,
+    cellStatus: "warning",
+  },
+  qc: {
+    label: "Pending QC",
+    icon: "magnifying-glass",
+    qcComplete: false,
+    cellStatus: "warning",
+  },
+  dataReview: {
+    label: "Pending data review",
+    icon: "glasses",
+    qcComplete: true,
+    cellStatus: "warning",
+  },
+  passed: {
+    label: "Passed",
+    icon: "check",
+    qcComplete: true,
+  },
+  failed: {
+    label: "Failed",
+    icon: "xmark",
+    qcComplete: true,
+    cellStatus: "error",
+  },
+  topUp: {
+    label: "Top-up Required",
+    icon: "fill-drip",
+    qcComplete: true,
+    cellStatus: "warning",
+  },
+};

--- a/ts/data/requisition.ts
+++ b/ts/data/requisition.ts
@@ -1,4 +1,4 @@
-import { makeIcon, makeNameDiv } from "../util/html-utils";
+import { CellStatus, makeIcon, makeNameDiv } from "../util/html-utils";
 import {
   ColumnDefinition,
   SortDefinition,
@@ -77,6 +77,7 @@ export const informaticsReviewDefinition: TableDefinition<Requisition, void> = {
       addParentContents(requisition, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     latestActivityColumn,
   ],
@@ -121,4 +122,8 @@ function addTodoIcon(fragment: DocumentFragment) {
   const icon = makeIcon("person-digging");
   icon.title = "We're working on it!";
   fragment.appendChild(icon);
+}
+
+function todoHighlight(): CellStatus {
+  return "na";
 }

--- a/ts/data/requisition.ts
+++ b/ts/data/requisition.ts
@@ -1,0 +1,124 @@
+import { makeIcon, makeNameDiv } from "../util/html-utils";
+import {
+  ColumnDefinition,
+  SortDefinition,
+  TableDefinition,
+} from "../util/table-builder";
+import { urls } from "../util/urls";
+import { qcStatuses } from "./qc-status";
+
+export interface RequisitionQc {
+  qcPassed: boolean;
+  qcUser: string;
+  qcDate: string;
+}
+
+export interface Requisition {
+  id: number;
+  name: string;
+  informaticsReviews: RequisitionQc[];
+  draftReports: RequisitionQc[];
+  finalReports: RequisitionQc[];
+  latestActivityDate?: string;
+}
+
+const defaultSort: SortDefinition = {
+  columnTitle: "Latest Activity",
+  descending: true,
+  type: "date",
+};
+
+function qcStatusColumn(
+  getQcs: (requisition: Requisition) => RequisitionQc[]
+): ColumnDefinition<Requisition, void> {
+  return {
+    title: "QC Status",
+    addParentContents(requisition, fragment) {
+      const status = getRequisitionQcStatus(getQcs(requisition));
+      const icon = makeIcon(status.icon);
+      icon.title = status.label;
+      fragment.appendChild(icon);
+    },
+    getCellHighlight(requisition) {
+      const status = getRequisitionQcStatus(getQcs(requisition));
+      return status.cellStatus || null;
+    },
+  };
+}
+
+const requisitionColumn: ColumnDefinition<Requisition, void> = {
+  title: "Requisition",
+  addParentContents(requisition, fragment) {
+    fragment.appendChild(
+      makeNameDiv(requisition.name, urls.miso.requisition(requisition.id))
+    );
+  },
+  sortType: "text",
+};
+
+const latestActivityColumn: ColumnDefinition<Requisition, void> = {
+  title: "Latest Activity",
+  sortType: "date",
+  addParentContents(requisition, fragment) {
+    fragment.appendChild(
+      document.createTextNode(requisition.latestActivityDate || "")
+    );
+  },
+};
+
+export const informaticsReviewDefinition: TableDefinition<Requisition, void> = {
+  queryUrl: urls.rest.requisitions,
+  defaultSort: defaultSort,
+  columns: [
+    qcStatusColumn((requisition) => requisition.informaticsReviews),
+    requisitionColumn,
+    {
+      title: "(Metric Columns)",
+      addParentContents(requisition, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    latestActivityColumn,
+  ],
+};
+
+export const draftReportDefinition: TableDefinition<Requisition, void> = {
+  queryUrl: urls.rest.requisitions,
+  defaultSort: defaultSort,
+  columns: [
+    qcStatusColumn((requisition) => requisition.draftReports),
+    requisitionColumn,
+    latestActivityColumn,
+  ],
+};
+
+export const finalReportDefinition: TableDefinition<Requisition, void> = {
+  queryUrl: urls.rest.requisitions,
+  defaultSort: defaultSort,
+  columns: [
+    qcStatusColumn((requisition) => requisition.finalReports),
+    requisitionColumn,
+    latestActivityColumn,
+  ],
+};
+
+export function getRequisitionQcStatus(qcs: RequisitionQc[]) {
+  // return status of latest QC in-case there are multiple
+  if (!qcs.length) {
+    return qcStatuses.qc;
+  }
+  const latest = getLatestRequisitionQc(qcs);
+  return latest.qcPassed ? qcStatuses.passed : qcStatuses.failed;
+}
+
+export function getLatestRequisitionQc(qcs: RequisitionQc[]) {
+  return qcs.reduce((previous, current) =>
+    previous.qcDate > current.qcDate ? previous : current
+  );
+}
+
+function addTodoIcon(fragment: DocumentFragment) {
+  const icon = makeIcon("person-digging");
+  icon.title = "We're working on it!";
+  fragment.appendChild(icon);
+}

--- a/ts/data/sample.ts
+++ b/ts/data/sample.ts
@@ -1,0 +1,246 @@
+import { addMisoIcon, makeIcon, makeNameDiv } from "../util/html-utils";
+import {
+  ColumnDefinition,
+  SortDefinition,
+  TableDefinition,
+} from "../util/table-builder";
+import { urls } from "../util/urls";
+import { Run } from "./case";
+import { QcStatus, qcStatuses } from "./qc-status";
+
+export interface Sample {
+  id: string;
+  name: string;
+  tissueOrigin: string;
+  tissueType: string;
+  timepoint: string;
+  groupId: string;
+  targetedSequencing: string;
+  createdDate: string;
+  volume?: number;
+  concentration?: number;
+  run: Run;
+  qcPassed: boolean;
+  qcReason: string;
+  qcUser: string;
+  qcDate: string;
+  dataReviewPassed: boolean;
+  dataReviewUser: string;
+  dataReviewDate: string;
+  latestActivityDate: string;
+}
+
+const defaultSort: SortDefinition = {
+  columnTitle: "Latest Activity",
+  descending: true,
+  type: "date",
+};
+
+const qcStatusColumn: ColumnDefinition<Sample, void> = {
+  title: "QC Status",
+  addParentContents(sample, fragment) {
+    const status = getSampleQcStatus(sample);
+    const icon = makeIcon(status.icon);
+    icon.title = status.label;
+    fragment.appendChild(icon);
+  },
+  getCellHighlight(sample) {
+    const status = getSampleQcStatus(sample);
+    return status.cellStatus || null;
+  },
+};
+
+const nameColumn: ColumnDefinition<Sample, void> = {
+  title: "Name",
+  addParentContents(sample, fragment) {
+    fragment.appendChild(makeNameDiv(sample.name, urls.miso.sample(sample.id)));
+    if (sample.run) {
+      fragment.appendChild(makeNameDiv(sample.run.name, "#")); // TODO: correct MISO link
+      // TODO: add Dashi icon link
+    }
+  },
+  sortType: "text",
+};
+
+const tissueAttributesColumn: ColumnDefinition<Sample, void> = {
+  title: "Tissue Attributes",
+  addParentContents(sample, fragment) {
+    const tumourDetailDiv = document.createElement("div");
+    tumourDetailDiv.appendChild(
+      document.createTextNode(
+        `${sample.tissueOrigin} ${sample.tissueType}` +
+          (sample.timepoint ? " " + sample.timepoint : "")
+      )
+    );
+    fragment.appendChild(tumourDetailDiv);
+  },
+};
+
+const designColumn: ColumnDefinition<Sample, void> = {
+  title: "Design",
+  addParentContents(sample, fragment) {
+    addTodoIcon(fragment); // TODO
+  },
+};
+
+const sequencingAttributesColumn: ColumnDefinition<Sample, void> = {
+  title: "Sequencing Attributes",
+  addParentContents(sample, fragment) {
+    if (sample.run) {
+      addTodoIcon(fragment); // TODO
+    } else {
+      fragment.appendChild(document.createTextNode("N/A"));
+    }
+  },
+  getCellHighlight(sample) {
+    return sample.run ? null : "na";
+  },
+};
+
+const latestActivityColumn: ColumnDefinition<Sample, void> = {
+  title: "Latest Activity",
+  sortType: "date",
+  addParentContents(sample, fragment) {
+    fragment.appendChild(document.createTextNode(sample.latestActivityDate));
+  },
+};
+
+export const receiptDefinition: TableDefinition<Sample, void> = {
+  queryUrl: urls.rest.receipts,
+  defaultSort: defaultSort,
+  columns: [
+    qcStatusColumn,
+    nameColumn,
+    {
+      title: "Requisition",
+      addParentContents(sample, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    {
+      title: "Secondary ID",
+      addParentContents(sample, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    tissueAttributesColumn,
+    {
+      title: "(Metric Columns)",
+      addParentContents(sample, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    latestActivityColumn,
+  ],
+};
+
+export const extractionDefinition: TableDefinition<Sample, void> = {
+  queryUrl: urls.rest.extractions,
+  defaultSort: defaultSort,
+  columns: [
+    qcStatusColumn,
+    nameColumn,
+    tissueAttributesColumn,
+    {
+      title: "Nucleic Acid Type",
+      addParentContents(sample, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    {
+      title: "(Metric Columns)",
+      addParentContents(sample, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    latestActivityColumn,
+  ],
+};
+
+export const libraryPreparationDefinition: TableDefinition<Sample, void> = {
+  queryUrl: urls.rest.libraryPreparations,
+  defaultSort: defaultSort,
+  columns: [
+    qcStatusColumn,
+    nameColumn,
+    tissueAttributesColumn,
+    designColumn,
+    {
+      title: "(Metric Columns)",
+      addParentContents(sample, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    latestActivityColumn,
+  ],
+};
+
+export const libraryQualificationsDefinition: TableDefinition<Sample, void> = {
+  queryUrl: urls.rest.libraryQualifications,
+  defaultSort: defaultSort,
+  columns: [
+    qcStatusColumn,
+    nameColumn,
+    tissueAttributesColumn,
+    designColumn,
+    sequencingAttributesColumn,
+    {
+      title: "(Metric Columns)",
+      addParentContents(sample, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    latestActivityColumn,
+  ],
+};
+
+export const fullDepthSequencingDefinition: TableDefinition<Sample, void> = {
+  queryUrl: urls.rest.fullDepthSequencings,
+  defaultSort: defaultSort,
+  columns: [
+    qcStatusColumn,
+    nameColumn,
+    tissueAttributesColumn,
+    designColumn,
+    sequencingAttributesColumn,
+    {
+      title: "(Metric Columns)",
+      addParentContents(sample, fragment) {
+        addTodoIcon(fragment); // TODO
+      },
+    },
+    latestActivityColumn,
+  ],
+};
+
+export function getSampleQcStatus(sample: Sample): QcStatus {
+  const firstStatus = getFirstReviewStatus(sample);
+  if (sample.run && firstStatus.qcComplete) {
+    // run-libraries also have data review
+    if (!sample.dataReviewDate) {
+      return qcStatuses.dataReview;
+    } else if (sample.dataReviewPassed === false) {
+      return qcStatuses.failed;
+    }
+    // if data review is passed, first sign-off status is used
+  }
+  return firstStatus;
+}
+
+function getFirstReviewStatus(sample: Sample) {
+  if (sample.qcPassed === false) {
+    return qcStatuses.failed;
+  } else if (sample.qcPassed === true) {
+    return qcStatuses.passed;
+  } else if (sample.qcReason === "Top-up Required") {
+    return qcStatuses.topUp;
+  } else {
+    return qcStatuses.qc;
+  }
+}
+
+function addTodoIcon(fragment: DocumentFragment) {
+  const icon = makeIcon("person-digging");
+  icon.title = "We're working on it!";
+  fragment.appendChild(icon);
+}

--- a/ts/data/sample.ts
+++ b/ts/data/sample.ts
@@ -1,4 +1,9 @@
-import { addMisoIcon, makeIcon, makeNameDiv } from "../util/html-utils";
+import {
+  addMisoIcon,
+  CellStatus,
+  makeIcon,
+  makeNameDiv,
+} from "../util/html-utils";
 import {
   ColumnDefinition,
   SortDefinition,
@@ -81,6 +86,7 @@ const designColumn: ColumnDefinition<Sample, void> = {
   addParentContents(sample, fragment) {
     addTodoIcon(fragment); // TODO
   },
+  getCellHighlight: todoHighlight,
 };
 
 const sequencingAttributesColumn: ColumnDefinition<Sample, void> = {
@@ -92,9 +98,7 @@ const sequencingAttributesColumn: ColumnDefinition<Sample, void> = {
       fragment.appendChild(document.createTextNode("N/A"));
     }
   },
-  getCellHighlight(sample) {
-    return sample.run ? null : "na";
-  },
+  getCellHighlight: todoHighlight,
 };
 
 const latestActivityColumn: ColumnDefinition<Sample, void> = {
@@ -116,12 +120,14 @@ export const receiptDefinition: TableDefinition<Sample, void> = {
       addParentContents(sample, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     {
       title: "Secondary ID",
       addParentContents(sample, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     tissueAttributesColumn,
     {
@@ -129,6 +135,7 @@ export const receiptDefinition: TableDefinition<Sample, void> = {
       addParentContents(sample, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     latestActivityColumn,
   ],
@@ -146,12 +153,14 @@ export const extractionDefinition: TableDefinition<Sample, void> = {
       addParentContents(sample, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     {
       title: "(Metric Columns)",
       addParentContents(sample, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     latestActivityColumn,
   ],
@@ -170,6 +179,7 @@ export const libraryPreparationDefinition: TableDefinition<Sample, void> = {
       addParentContents(sample, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     latestActivityColumn,
   ],
@@ -189,6 +199,7 @@ export const libraryQualificationsDefinition: TableDefinition<Sample, void> = {
       addParentContents(sample, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     latestActivityColumn,
   ],
@@ -208,6 +219,7 @@ export const fullDepthSequencingDefinition: TableDefinition<Sample, void> = {
       addParentContents(sample, fragment) {
         addTodoIcon(fragment); // TODO
       },
+      getCellHighlight: todoHighlight,
     },
     latestActivityColumn,
   ],
@@ -243,4 +255,8 @@ function addTodoIcon(fragment: DocumentFragment) {
   const icon = makeIcon("person-digging");
   icon.title = "We're working on it!";
   fragment.appendChild(icon);
+}
+
+function todoHighlight(): CellStatus {
+  return "na";
 }

--- a/ts/details.ts
+++ b/ts/details.ts
@@ -1,0 +1,36 @@
+import { caseDefinition } from "./data/case";
+import {
+  draftReportDefinition,
+  finalReportDefinition,
+  informaticsReviewDefinition,
+} from "./data/requisition";
+import {
+  extractionDefinition,
+  fullDepthSequencingDefinition,
+  libraryPreparationDefinition,
+  libraryQualificationsDefinition,
+  receiptDefinition,
+} from "./data/sample";
+import { TableBuilder } from "./util/table-builder";
+
+new TableBuilder(caseDefinition, "casesTableContainer").build();
+new TableBuilder(receiptDefinition, "receiptsTableContainer").build();
+new TableBuilder(extractionDefinition, "extractionsTableContainer").build();
+new TableBuilder(
+  libraryPreparationDefinition,
+  "libraryPreparationsTableContainer"
+).build();
+new TableBuilder(
+  libraryQualificationsDefinition,
+  "libraryQualificationsTableContainer"
+).build();
+new TableBuilder(
+  fullDepthSequencingDefinition,
+  "fullDepthSequencingsTableContainer"
+).build();
+new TableBuilder(
+  informaticsReviewDefinition,
+  "informaticsReviewsTableContainer"
+).build();
+new TableBuilder(draftReportDefinition, "draftReportsTableContainer").build();
+new TableBuilder(finalReportDefinition, "finalReportsTableContainer").build();

--- a/ts/util/html-utils.ts
+++ b/ts/util/html-utils.ts
@@ -34,8 +34,10 @@ export function addMisoIcon(container: HTMLElement, url: string) {
   const a = document.createElement("a");
   a.setAttribute("href", url);
   const img = document.createElement("img");
+  img.className = "max-w-none";
   img.src = "/img/miso_logo.svg";
   img.alt = "View in MISO";
+  img.title = "View in MISO";
   a.appendChild(img);
   container.appendChild(a);
 }
@@ -85,4 +87,14 @@ export function makeClickout() {
   clickout.className =
     "bg-transparent fixed inset-0 w-full h-full cursor-default hidden";
   return clickout;
+}
+
+export function makeNameDiv(name: string, misoUrl: string) {
+  const div = document.createElement("div");
+  div.className = "flex flex-row space-x-2 items-center";
+  const nameSpan = document.createElement("span");
+  nameSpan.innerText = name;
+  div.appendChild(nameSpan);
+  addMisoIcon(div, misoUrl);
+  return div;
 }

--- a/ts/util/requests.ts
+++ b/ts/util/requests.ts
@@ -22,10 +22,3 @@ function getMetaContent(name: string) {
   }
   return tag.getAttribute("content");
 }
-
-const restBaseUrl = "/rest";
-
-const casesBaseUrl = restBaseUrl + "/cases";
-export const cases = {
-  query: casesBaseUrl,
-};

--- a/ts/util/urls.ts
+++ b/ts/util/urls.ts
@@ -1,8 +1,26 @@
 import { siteConfig } from "./site-config";
 
+const restBaseUrl = "/rest";
+
 export const urls = {
+  dimsum: {
+    project: (name: string) => `/projects/${name}`,
+  },
+  rest: {
+    cases: `${restBaseUrl}/cases`,
+    receipts: `${restBaseUrl}/receipts`,
+    extractions: `${restBaseUrl}/extractions`,
+    libraryPreparations: `${restBaseUrl}/library-preparations`,
+    libraryQualifications: `${restBaseUrl}/library-qualifications`,
+    fullDepthSequencings: `${restBaseUrl}/full-depth-sequencings`,
+    requisitions: `${restBaseUrl}/requisitions`,
+  },
   miso: {
     sample: function (sampleId: string) {
+      const match = sampleId.match("^\\d+_\\d+_LDI(\\d+)$");
+      if (match) {
+        return makeMisoUrl("libraryaliquot", match[1]);
+      }
       const prefix = sampleId.substring(0, 3);
       const id = parseInt(sampleId.substring(3));
       switch (prefix) {
@@ -13,11 +31,13 @@ export const urls = {
         case "LDI":
           return makeMisoUrl("libraryaliquot", id);
         default:
-          throw new Error(`Unhandled ID prefix: ${prefix}`);
+          throw new Error(`Unhandled ID pattern: ${sampleId}`);
       }
     },
     project: (shortName: string) => makeMisoUrl("project/shortname", shortName),
     run: (runId: number) => makeMisoUrl("run", runId),
+    requisition: (requisitionId: number) =>
+      makeMisoUrl("requisition", requisitionId),
   },
   dashi: {
     singleLaneTar: (runName: string) => makeDashiSingleLaneUrl("tar", runName),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ module.exports = {
   mode: "production",
   entry: {
     index: "./ts/index.ts",
+    details: "./ts/details.ts",
   },
   module: {
     rules: [


### PR DESCRIPTION
Will create separate tickets for filling in the missing columns (mostly metrics), and filtering tables besides the cases table.

I changed the default page size to 10 items to reduce the scrolling needed to get to other tables. @Arcslogger suggested changing this to a tabbed interface so only one table is visible at a time, which I think would be a huge improvement. We'll discuss this with users at the next meeting