### PR TITLE
[GLT-3718] show skipped QC gates as N/A

### DIFF
--- a/src/main/java/ca/on/oicr/gsi/dimsum/CaseLoader.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/CaseLoader.java
@@ -268,11 +268,15 @@ public class CaseLoader {
     }
     List<Test> tests = new ArrayList<>();
     for (JsonNode testNode : testsNode) {
-      tests.add(new Test.Builder().name(parseString(testNode, "name", true))
+      tests.add(new Test.Builder()
+          .name(parseString(testNode, "name", true))
           .tissueOrigin(parseString(testNode, "tissue_origin"))
           .tissueType(parseString(testNode, "tissue_type"))
-          .timepoint(parseString(testNode, "timepoint")).groupId(parseString(testNode, "group_id"))
+          .timepoint(parseString(testNode, "timepoint"))
+          .groupId(parseString(testNode, "group_id"))
           .targetedSequencing(parseString(testNode, "targeted_sequencing"))
+          .extractionSkipped(parseBoolean(testNode, "extraction_skipped"))
+          .libraryPreparationSkipped(parseBoolean(testNode, "library_preparation_skipped"))
           .extractions(parseIdsAndGet(testNode, "extraction_ids", JsonNode::asText, samplesById))
           .libraryPreparations(
               parseIdsAndGet(testNode, "library_preparation_ids", JsonNode::asText, samplesById))

--- a/src/main/java/ca/on/oicr/gsi/dimsum/data/Test.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/data/Test.java
@@ -20,6 +20,8 @@ public class Test {
   private final String timepoint;
   private final String groupId;
   private final String targetedSequencing;
+  private final boolean extractionSkipped;
+  private final boolean libraryPreparationSkipped;
   private final List<Sample> extractions;
   private final List<Sample> libraryPreparations;
   private final List<Sample> libraryQualifications;
@@ -33,6 +35,8 @@ public class Test {
     this.timepoint = builder.timepoint;
     this.groupId = builder.groupId;
     this.targetedSequencing = builder.targetedSequencing;
+    this.extractionSkipped = builder.extractionSkipped;
+    this.libraryPreparationSkipped = builder.libraryPreparationSkipped;
     this.extractions =
         builder.extractions == null ? emptyList() : unmodifiableList(builder.extractions);
     this.libraryPreparations = builder.libraryPreparations == null ? emptyList()
@@ -72,6 +76,14 @@ public class Test {
     return targetedSequencing;
   }
 
+  public boolean isExtractionSkipped() {
+    return extractionSkipped;
+  }
+
+  public boolean isLibraryPreparationSkipped() {
+    return libraryPreparationSkipped;
+  }
+
   public List<Sample> getExtractions() {
     return extractions;
   }
@@ -100,6 +112,8 @@ public class Test {
     private String timepoint;
     private String groupId;
     private String targetedSequencing;
+    private boolean extractionSkipped;
+    private boolean libraryPreparationSkipped;
     private List<Sample> extractions;
     private List<Sample> libraryPreparations;
     private List<Sample> libraryQualifications;
@@ -132,6 +146,16 @@ public class Test {
 
     public Builder targetedSequencing(String targetedSequencing) {
       this.targetedSequencing = targetedSequencing;
+      return this;
+    }
+
+    public Builder extractionSkipped(boolean extractionSkipped) {
+      this.extractionSkipped = extractionSkipped;
+      return this;
+    }
+
+    public Builder libraryPreparationSkipped(boolean libraryPreparationSkipped) {
+      this.libraryPreparationSkipped = libraryPreparationSkipped;
       return this;
     }
 

--- a/src/test/resources/testdata/cases.json
+++ b/src/test/resources/testdata/cases.json
@@ -25,6 +25,8 @@
         "timepoint": null,
         "group_id": "proj-extnl_BC",
         "targeted_sequencing": null,
+        "extraction_skipped": false,
+        "library_preparation_skipped": false,
         "extraction_ids": [
           "SAM413593"
         ],
@@ -46,6 +48,8 @@
         "timepoint": null,
         "group_id": "proj-extnl_1_5",
         "targeted_sequencing": null,
+        "extraction_skipped": false,
+        "library_preparation_skipped": false,
         "extraction_ids": [
           "SAM413648"
         ],
@@ -66,6 +70,8 @@
         "timepoint": null,
         "group_id": "proj-extnl_1_5",
         "targeted_sequencing": null,
+        "extraction_skipped": false,
+        "library_preparation_skipped": false,
         "extraction_ids": [
           "SAM413735"
         ],

--- a/ts/data/case.ts
+++ b/ts/data/case.ts
@@ -35,6 +35,8 @@ export interface Test {
   timepoint: string;
   groupId: string;
   targetedSequencing: string;
+  extractionSkipped: boolean;
+  libraryPreparationSkipped: boolean;
   extractions: Sample[];
   libraryPreparations: Sample[];
   libraryQualifications: Sample[];
@@ -208,6 +210,10 @@ export const caseDefinition: TableDefinition<Case, Test> = {
         if (handleNaSamplePhase(kase, test.extractions, fragment)) {
           return;
         }
+        if (!test.extractions.length && test.extractionSkipped) {
+          addNaText(fragment);
+          return;
+        }
         addSampleIcons(test.extractions, fragment);
         if (
           samplePhaseComplete(kase.receipts) &&
@@ -221,6 +227,9 @@ export const caseDefinition: TableDefinition<Case, Test> = {
       },
       getCellHighlight(kase, test) {
         test = assertNotNull(test);
+        if (!test.extractions.length && test.extractionSkipped) {
+          return "na";
+        }
         return getSamplePhaseHighlight(kase, test.extractions);
       },
     },
@@ -229,6 +238,13 @@ export const caseDefinition: TableDefinition<Case, Test> = {
       child: true,
       addChildContents(test, kase, fragment) {
         if (handleNaSamplePhase(kase, test.libraryPreparations, fragment)) {
+          return;
+        }
+        if (
+          !test.libraryPreparations.length &&
+          test.libraryPreparationSkipped
+        ) {
+          addNaText(fragment);
           return;
         }
         addSampleIcons(test.libraryPreparations, fragment);
@@ -244,6 +260,12 @@ export const caseDefinition: TableDefinition<Case, Test> = {
       },
       getCellHighlight(kase, test) {
         test = assertNotNull(test);
+        if (
+          !test.libraryPreparations.length &&
+          test.libraryPreparationSkipped
+        ) {
+          return "na";
+        }
         return getSamplePhaseHighlight(kase, test.libraryPreparations);
       },
     },


### PR DESCRIPTION
Should not be merged until the required qc-gate-etl change goes into production: https://bitbucket.oicr.on.ca/projects/GSI/repos/qc-gate-etl/pull-requests/39/overview