### PR TITLE
[GLT-3757] Identify text fields

### DIFF
--- a/ts/data/case.ts
+++ b/ts/data/case.ts
@@ -6,6 +6,7 @@ import {
   addMisoIcon,
   makeNameDiv,
   addNaText,
+  addTextDiv,
 } from "../util/html-utils";
 import { urls } from "../util/urls";
 import { siteConfig } from "../util/site-config";
@@ -190,23 +191,11 @@ export const caseDefinition: TableDefinition<Case, Test> = {
           )
         );
         const tooltipDiv = document.createElement("div");
-        const tissueOriginDiv = document.createElement("div");
-        tissueOriginDiv.appendChild(
-          document.createTextNode(`Tissue Origin: ${kase.tissueOrigin}`)
-        );
-        tooltipDiv.appendChild(tissueOriginDiv);
-        const tissueTypeDiv = document.createElement("div");
-        tissueTypeDiv.appendChild(
-          document.createTextNode(`Tissue Type: ${kase.tissueType}`)
-        );
-        tooltipDiv.appendChild(tissueTypeDiv);
-        const timepointDiv = document.createElement("div");
-        timepointDiv.appendChild(
-          document.createTextNode(
-            kase.timepoint ? `\nTimepoint: ${kase.timepoint}` : ""
-          )
-        );
-        tooltipDiv.appendChild(timepointDiv);
+        addTextDiv(`Tissue Origin: ${kase.tissueOrigin}`, tooltipDiv);
+        addTextDiv(`Tissue Type: ${kase.tissueType}`, tooltipDiv);
+        if (kase.timepoint) {
+          addTextDiv(`Timepoint: ${kase.timepoint}`, tooltipDiv);
+        }
         tooltipInstance.addTarget(tumourDetailDiv, tooltipDiv);
         fragment.appendChild(tumourDetailDiv);
       },

--- a/ts/data/case.ts
+++ b/ts/data/case.ts
@@ -172,9 +172,14 @@ export const caseDefinition: TableDefinition<Case, Test> = {
         fragment.appendChild(nameDiv);
 
         const externalNameDiv = document.createElement("div");
-        externalNameDiv.appendChild(document.createTextNode(kase.donor.externalName));
+        externalNameDiv.appendChild(
+          document.createTextNode(kase.donor.externalName)
+        );
         const tooltipInstance = Tooltip.getInstance();
-        tooltipInstance.addTarget(externalNameDiv, makeNameDiv("External Name", ""));
+        tooltipInstance.addTarget(
+          externalNameDiv,
+          document.createTextNode("External Name")
+        );
         fragment.appendChild(externalNameDiv);
 
         const tumourDetailDiv = document.createElement("div");
@@ -184,7 +189,10 @@ export const caseDefinition: TableDefinition<Case, Test> = {
               (kase.timepoint ? " " + kase.timepoint : "")
           )
         );
-        tooltipInstance.addTarget(tumourDetailDiv, makeNameDiv("Timepoint", ""));
+        tooltipInstance.addTarget(
+          tumourDetailDiv,
+          document.createTextNode("Timepoint")
+        );
         fragment.appendChild(tumourDetailDiv);
       },
     },
@@ -253,7 +261,10 @@ export const caseDefinition: TableDefinition<Case, Test> = {
           const groupIdDiv = document.createElement("div");
           groupIdDiv.appendChild(document.createTextNode(test.groupId));
           const tooltipInstance = Tooltip.getInstance();
-          tooltipInstance.addTarget(groupIdDiv, makeNameDiv("Group ID", "", ""));
+          tooltipInstance.addTarget(
+            groupIdDiv,
+            document.createTextNode("Group ID")
+          );
           fragment.appendChild(groupIdDiv);
         }
       },

--- a/ts/data/case.ts
+++ b/ts/data/case.ts
@@ -191,7 +191,11 @@ export const caseDefinition: TableDefinition<Case, Test> = {
         );
         tooltipInstance.addTarget(
           tumourDetailDiv,
-          document.createTextNode("Timepoint")
+          document.createTextNode(
+            `Tissue Origin: ${kase.tissueOrigin}\n` +
+              `Tissue Type: ${kase.tissueType}` +
+              (kase.timepoint ? `\nTimepoint: ${kase.timepoint}` : "")
+          )
         );
         fragment.appendChild(tumourDetailDiv);
       },

--- a/ts/data/case.ts
+++ b/ts/data/case.ts
@@ -174,7 +174,7 @@ export const caseDefinition: TableDefinition<Case, Test> = {
         const externalNameDiv = document.createElement("div");
         externalNameDiv.appendChild(document.createTextNode(kase.donor.externalName));
         const tooltipInstance = Tooltip.getInstance();
-        tooltipInstance.addTarget(externalNameDiv, makeNameDiv("External Name", "", ""));
+        tooltipInstance.addTarget(externalNameDiv, makeNameDiv("External Name", ""));
         fragment.appendChild(externalNameDiv);
 
         const tumourDetailDiv = document.createElement("div");
@@ -184,6 +184,7 @@ export const caseDefinition: TableDefinition<Case, Test> = {
               (kase.timepoint ? " " + kase.timepoint : "")
           )
         );
+        tooltipInstance.addTarget(tumourDetailDiv, makeNameDiv("Timepoint", ""));
         fragment.appendChild(tumourDetailDiv);
       },
     },

--- a/ts/data/case.ts
+++ b/ts/data/case.ts
@@ -189,14 +189,25 @@ export const caseDefinition: TableDefinition<Case, Test> = {
               (kase.timepoint ? " " + kase.timepoint : "")
           )
         );
-        tooltipInstance.addTarget(
-          tumourDetailDiv,
+        const tooltipDiv = document.createElement("div");
+        const tissueOriginDiv = document.createElement("div");
+        tissueOriginDiv.appendChild(
+          document.createTextNode(`Tissue Origin: ${kase.tissueOrigin}`)
+        );
+        tooltipDiv.appendChild(tissueOriginDiv);
+        const tissueTypeDiv = document.createElement("div");
+        tissueTypeDiv.appendChild(
+          document.createTextNode(`Tissue Type: ${kase.tissueType}`)
+        );
+        tooltipDiv.appendChild(tissueTypeDiv);
+        const timepointDiv = document.createElement("div");
+        timepointDiv.appendChild(
           document.createTextNode(
-            `Tissue Origin: ${kase.tissueOrigin}\n` +
-              `Tissue Type: ${kase.tissueType}` +
-              (kase.timepoint ? `\nTimepoint: ${kase.timepoint}` : "")
+            kase.timepoint ? `\nTimepoint: ${kase.timepoint}` : ""
           )
         );
+        tooltipDiv.appendChild(timepointDiv);
+        tooltipInstance.addTarget(tumourDetailDiv, tooltipDiv);
         fragment.appendChild(tumourDetailDiv);
       },
     },

--- a/ts/data/case.ts
+++ b/ts/data/case.ts
@@ -172,9 +172,9 @@ export const caseDefinition: TableDefinition<Case, Test> = {
         fragment.appendChild(nameDiv);
 
         const externalNameDiv = document.createElement("div");
-        externalNameDiv.appendChild(
-          document.createTextNode(kase.donor.externalName)
-        );
+        externalNameDiv.appendChild(document.createTextNode(kase.donor.externalName));
+        const tooltipInstance = Tooltip.getInstance();
+        tooltipInstance.addTarget(externalNameDiv, makeNameDiv("External Name", "", ""));
         fragment.appendChild(externalNameDiv);
 
         const tumourDetailDiv = document.createElement("div");
@@ -251,6 +251,8 @@ export const caseDefinition: TableDefinition<Case, Test> = {
         if (test.groupId) {
           const groupIdDiv = document.createElement("div");
           groupIdDiv.appendChild(document.createTextNode(test.groupId));
+          const tooltipInstance = Tooltip.getInstance();
+          tooltipInstance.addTarget(groupIdDiv, makeNameDiv("Group ID", "", ""));
           fragment.appendChild(groupIdDiv);
         }
       },

--- a/ts/util/html-utils.ts
+++ b/ts/util/html-utils.ts
@@ -113,9 +113,7 @@ export function makeNameDiv(name: string, misoUrl: string, dimsumUrl?: string) {
     nameSpan.innerText = name;
     div.appendChild(nameSpan);
   }
-  if (misoUrl) {
-    addMisoIcon(div, misoUrl);
-  }
+  addMisoIcon(div, misoUrl);
   return div;
 }
 

--- a/ts/util/html-utils.ts
+++ b/ts/util/html-utils.ts
@@ -120,3 +120,9 @@ export function makeNameDiv(name: string, misoUrl: string, dimsumUrl?: string) {
 export function addNaText(fragment: DocumentFragment) {
   fragment.appendChild(document.createTextNode("N/A"));
 }
+
+export function addTextDiv(text: string, container: HTMLElement) {
+  const divContainer = document.createElement("div");
+  divContainer.appendChild(document.createTextNode(text));
+  container.appendChild(divContainer);
+}

--- a/ts/util/html-utils.ts
+++ b/ts/util/html-utils.ts
@@ -113,7 +113,9 @@ export function makeNameDiv(name: string, misoUrl: string, dimsumUrl?: string) {
     nameSpan.innerText = name;
     div.appendChild(nameSpan);
   }
-  addMisoIcon(div, misoUrl);
+  if (misoUrl) {
+    addMisoIcon(div, misoUrl);
+  }
   return div;
 }
 


### PR DESCRIPTION
Add tool tips for identifying non-intuitive text fields (group ids, external names, etc.). As per [GLT-3757](https://jira.oicr.on.ca/browse/GLT-3757).