### PR TITLE
fixed positioning of dropdown arrow icon

### DIFF
--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -56,7 +56,6 @@ export class Dropdown {
     dropdownButtonText.innerHTML = makeDisplayText(displayLabel, defaultOption);
     dropdownButton.appendChild(dropdownButtonText);
     dropdownButton.appendChild(makeIcon("caret-down"));
-    dropdownButton.className += `space-x-2`;
     dropdownClickout.onclick = defaultOption ? toggleMenu : invalidInput;
 
     DropdownOptions.forEach((option) => {

--- a/ts/util/html-utils.ts
+++ b/ts/util/html-utils.ts
@@ -81,7 +81,7 @@ export function styleText(element: HTMLElement, style?: TextStyle | null) {
 // makes an icon with the corresponding Font Awesome name
 export function makeIcon(name: string) {
   const icon = document.createElement("i");
-  icon.className = `fa-solid fa-${name} items-center`;
+  icon.className = `fa-solid fa-${name}`;
   return icon;
 }
 


### PR DESCRIPTION
1. icons are not flexbox or grid containers, so `items-center` on them has no effect. `items-center` should be on the container, which it was, but...
2. appending to `dropdownButton.className` without including a space broke one of the existing classes (`items-center`) as well as the one being added. Can use `element.classList.add` to add classes more safely, but in this case, `dropdownButton` already had `space-x-2`, so it was unnecessary