### PR TITLE
[GLT-3744] Add escape option for filters

### DIFF
--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -26,7 +26,6 @@ export class BasicDropdownOption implements DropdownOption {
 
 export class Dropdown {
   private dropdownContainer: HTMLElement;
-
   // displayTemporary: set to true if the created dropdown menu can be removed
   // (by user interaction or otherwise), else set to false (or undefined) if otherwise
   constructor(
@@ -54,41 +53,45 @@ export class Dropdown {
       dropdownClickout.classList.toggle("hidden");
     };
 
-    dropdownButton.onclick = toggleMenu;
+    var handleKeydown = (event: KeyboardEvent) => {
+      // only remove the button in question if it is not already hidden
+      if (event.key === "Esc" || event.key === "Escape") {
+        if (displayTemporary) {
+          this.dropdownContainer.remove();
+        } else {
+          if (
+            !dropdownMenuContainer.classList.contains("hidden") &&
+            !dropdownClickout.classList.contains("hidden")
+          ) {
+            toggleMenu();
+          }
+        }
+        document.removeEventListener("keydown", handleKeydown);
+        console.log("REMOVE ON HANDLE");
+      }
+    };
+
+    dropdownButton.onclick = () => {
+      toggleMenu();
+      if (!dropdownMenuContainer.classList.contains("hidden")) {
+        console.log("ADDED ON DROPDOWN CLICK");
+        document.addEventListener("keydown", handleKeydown);
+      }
+    };
     // close dropdown menu by clicking outside of the menu or by hitting Esc
     dropdownClickout.onclick = () => {
       if (displayTemporary && !dropdownButton.classList.contains("hidden")) {
-        dropdownButton.remove();
+        this.dropdownContainer.remove();
       }
       toggleMenu();
+      console.log("REMOVED ON CLICKOUT");
+      document.removeEventListener("keydown", handleKeydown);
     };
-    document.addEventListener(
-      "keydown",
-      (event) => {
-        // only remove the button in question if it is not already hidden
-        if (event.key === "Esc" || event.key === "Escape") {
-          const menuHidden = dropdownMenuContainer.classList.contains("hidden");
-          const clickoutHidden = dropdownClickout.classList.contains("hidden");
-          if (displayTemporary) {
-            // dropdown button is temporary, remove it and its corresponding elements
-            if (
-              !dropdownButton.classList.contains("hidden") &&
-              !menuHidden &&
-              !clickoutHidden
-            ) {
-              dropdownMenuContainer.remove();
-              dropdownButton.remove();
-            }
-          } else {
-            // button is NOT temporary, hide its corresponding elements if they are visible
-            if (!menuHidden && !clickoutHidden) {
-              toggleMenu();
-            }
-          }
-        }
-      },
-      displayTemporary ? { once: true } : false
-    );
+    // create an additional event listener for temporary buttons
+    if (displayTemporary) {
+      document.addEventListener("keydown", handleKeydown);
+      console.log("ADD ON TEMP BUTTON");
+    }
 
     DropdownOptions.forEach((option) => {
       const li = document.createElement("li");
@@ -105,6 +108,10 @@ export class Dropdown {
             );
           }
           toggleMenu();
+          if (dropdownMenuContainer.classList.contains("hidden")) {
+            document.removeEventListener("keydown", handleKeydown);
+            console.log("REMOVED ON CHOICE");
+          }
         });
       }
       dropdownMenuContainer.appendChild(li);
@@ -119,6 +126,9 @@ export class Dropdown {
 
   public getContainerTag() {
     return this.dropdownContainer;
+  }
+  public getDisplayTemporary() {
+    return this.getDisplayTemporary;
   }
 }
 

--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -46,6 +46,7 @@ export class Dropdown {
     dropdownButton.appendChild(makeIcon("caret-down"));
 
     const dropdownClickout = makeClickout();
+    dropdownClickout.classList.add("z-10");
     const dropdownMenuContainer = makeDropdownMenuContainer();
     const toggleMenu = () => {
       dropdownMenuContainer.classList.toggle("hidden");

--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -67,14 +67,12 @@ export class Dropdown {
           }
         }
         document.removeEventListener("keydown", handleKeydown);
-        console.log("REMOVE ON HANDLE");
       }
     };
 
     dropdownButton.onclick = () => {
       toggleMenu();
       if (!dropdownMenuContainer.classList.contains("hidden")) {
-        console.log("ADDED ON DROPDOWN CLICK");
         document.addEventListener("keydown", handleKeydown);
       }
     };
@@ -84,13 +82,11 @@ export class Dropdown {
         this.dropdownContainer.remove();
       }
       toggleMenu();
-      console.log("REMOVED ON CLICKOUT");
       document.removeEventListener("keydown", handleKeydown);
     };
     // create an additional event listener for temporary buttons
     if (displayTemporary) {
       document.addEventListener("keydown", handleKeydown);
-      console.log("ADD ON TEMP BUTTON");
     }
 
     DropdownOptions.forEach((option) => {
@@ -110,7 +106,6 @@ export class Dropdown {
           toggleMenu();
           if (dropdownMenuContainer.classList.contains("hidden")) {
             document.removeEventListener("keydown", handleKeydown);
-            console.log("REMOVED ON CHOICE");
           }
         });
       }

--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -47,39 +47,42 @@ export class Dropdown {
       dropdownMenuContainer.classList.remove("ring-2");
       dropdownClickout.classList.toggle("hidden");
     };
-    const toggleDropdownButton = () => {
-      // toggle whether or not a labeled button is removed
-      if (displayTemporary) {
-        dropdownButton.classList.toggle("hidden");
-      }
-      toggleMenu();
-    };
     dropdownButton.onclick = toggleMenu;
     dropdownButton.innerHTML = makeDisplayText(displayLabel, defaultOption);
     // close dropdown menu by clicking outside of the menu or by hitting Esc
-    dropdownClickout.onclick = toggleDropdownButton;
-    document.addEventListener("keydown", (event) => {
-      // only remove the button in question if it is not already hidden
-      if (event.key === "Esc" || event.key === "Escape") {
-        const menuHidden = dropdownMenuContainer.classList.contains("hidden");
-        const clickoutHidden = dropdownClickout.classList.contains("hidden");
-        if (displayTemporary) {
-          // dropdown button is temporary, hide its corresponding elements if they are visible
-          if (
-            !dropdownButton.classList.contains("hidden") &&
-            !menuHidden &&
-            !clickoutHidden
-          ) {
-            toggleDropdownButton();
-          }
-        } else {
-          // button is NOT temporary, hide its corresponding elements if they are visible
-          if (!menuHidden && !clickoutHidden) {
-            toggleMenu();
+    dropdownClickout.onclick = () => {
+      if (displayTemporary && !dropdownButton.classList.contains("hidden")) {
+        dropdownButton.remove();
+      }
+      toggleMenu();
+    };
+    document.addEventListener(
+      "keydown",
+      (event) => {
+        // only remove the button in question if it is not already hidden
+        if (event.key === "Esc" || event.key === "Escape") {
+          const menuHidden = dropdownMenuContainer.classList.contains("hidden");
+          const clickoutHidden = dropdownClickout.classList.contains("hidden");
+          if (displayTemporary) {
+            // dropdown button is temporary, remove it and its corresponding elements
+            if (
+              !dropdownButton.classList.contains("hidden") &&
+              !menuHidden &&
+              !clickoutHidden
+            ) {
+              dropdownMenuContainer.remove();
+              dropdownButton.remove();
+            }
+          } else {
+            // button is NOT temporary, hide its corresponding elements if they are visible
+            if (!menuHidden && !clickoutHidden) {
+              toggleMenu();
+            }
           }
         }
-      }
-    });
+      },
+      displayTemporary ? { once: true } : false
+    );
 
     DropdownOptions.forEach((option) => {
       const li = document.createElement("li");

--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -54,13 +54,7 @@ export class Dropdown {
       }
       toggleMenu();
     };
-    const invalidInput = () => {
-      dropdownMenuContainer.classList.add(
-        "ring-green-200",
-        "ring-2",
-        "ring-offset-1"
-      );
-    };
+
     dropdownButton.onclick = toggleMenu;
     dropdownButton.innerHTML = makeDisplayText(displayLabel, defaultOption);
     // close dropdown menu by clicking outside of the menu or by hitting Esc

--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -27,11 +27,14 @@ export class BasicDropdownOption implements DropdownOption {
 export class Dropdown {
   private dropdownContainer: HTMLElement;
 
+  // displayTemporary: set to true if the created dropdown menu can be removed
+  // (by user interaction or otherwise), else set to false (or undefined) if otherwise
   constructor(
     DropdownOptions: DropdownOption[],
     displaySelection: boolean,
     displayLabel?: string,
-    defaultOption?: string
+    defaultOption?: string,
+    displayTemporary?: boolean
   ) {
     this.dropdownContainer = document.createElement("div");
     this.dropdownContainer.classList.add("inline-block");
@@ -44,6 +47,13 @@ export class Dropdown {
       dropdownMenuContainer.classList.remove("ring-2");
       dropdownClickout.classList.toggle("hidden");
     };
+    const toggleDropdownButton = () => {
+      // toggle whether or not a labeled button is removed
+      if (displayTemporary) {
+        dropdownButton.classList.toggle("hidden");
+      }
+      toggleMenu();
+    };
     const invalidInput = () => {
       dropdownMenuContainer.classList.add(
         "ring-green-200",
@@ -53,8 +63,21 @@ export class Dropdown {
     };
     dropdownButton.onclick = toggleMenu;
     dropdownButton.innerHTML = makeDisplayText(displayLabel, defaultOption);
-    dropdownClickout.onclick = defaultOption ? toggleMenu : invalidInput;
+    // close dropdown menu by clicking outside of the menu or by hitting Esc
+    dropdownClickout.onclick = toggleDropdownButton;
+    dropdownClickout.addEventListener("keydown", (event) => {
+      // only remove the button in question if it is not already hidden
+      if (
+        (event.key === "Escape" || event.key === "Esc") &&
+        !dropdownButton.hidden &&
+        !dropdownClickout.hidden &&
+        !dropdownMenuContainer.hidden
+      ) {
+        toggleDropdownButton();
+      }
+    });
 
+    // circumvent disappearing buttons (unwanted behaviour) by checking whether the dropdown menu is meant to be "temporary"
     DropdownOptions.forEach((option) => {
       const li = document.createElement("li");
       option.render(li, this);

--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -54,24 +54,33 @@ export class Dropdown {
       }
       toggleMenu();
     };
-
     dropdownButton.onclick = toggleMenu;
     dropdownButton.innerHTML = makeDisplayText(displayLabel, defaultOption);
     // close dropdown menu by clicking outside of the menu or by hitting Esc
     dropdownClickout.onclick = toggleDropdownButton;
-    dropdownClickout.addEventListener("keydown", (event) => {
+    document.addEventListener("keydown", (event) => {
       // only remove the button in question if it is not already hidden
-      if (
-        (event.key === "Escape" || event.key === "Esc") &&
-        !dropdownButton.hidden &&
-        !dropdownClickout.hidden &&
-        !dropdownMenuContainer.hidden
-      ) {
-        toggleDropdownButton();
+      if (event.key === "Esc" || event.key === "Escape") {
+        const menuHidden = dropdownMenuContainer.classList.contains("hidden");
+        const clickoutHidden = dropdownClickout.classList.contains("hidden");
+        if (displayTemporary) {
+          // dropdown button is temporary, hide its corresponding elements if they are visible
+          if (
+            !dropdownButton.classList.contains("hidden") &&
+            !menuHidden &&
+            !clickoutHidden
+          ) {
+            toggleDropdownButton();
+          }
+        } else {
+          // button is NOT temporary, hide its corresponding elements if they are visible
+          if (!menuHidden && !clickoutHidden) {
+            toggleMenu();
+          }
+        }
       }
     });
 
-    // circumvent disappearing buttons (unwanted behaviour) by checking whether the dropdown menu is meant to be "temporary"
     DropdownOptions.forEach((option) => {
       const li = document.createElement("li");
       option.render(li, this);

--- a/ts/component/dropdown.ts
+++ b/ts/component/dropdown.ts
@@ -46,7 +46,6 @@ export class Dropdown {
     dropdownButton.appendChild(makeIcon("caret-down"));
 
     const dropdownClickout = makeClickout();
-    dropdownClickout.classList.add("z-10");
     const dropdownMenuContainer = makeDropdownMenuContainer();
     const toggleMenu = () => {
       dropdownMenuContainer.classList.toggle("hidden");

--- a/ts/component/table-builder.ts
+++ b/ts/component/table-builder.ts
@@ -305,7 +305,9 @@ export class TableBuilder<ParentType, ChildType> {
       const filterSuboptionsDropdown = new Dropdown(
         filterSuboptions,
         true,
-        filter.title
+        filter.title,
+        undefined,
+        true
       );
       filterContainer.insertBefore(
         filterSuboptionsDropdown.getContainerTag(),

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -1,5 +1,6 @@
 import { makeClickout, makeIcon } from "../util/html-utils";
 import { get } from "../util/requests";
+import { toggleLegend } from "./legend";
 
 export class TextInput {
   private container: HTMLElement;
@@ -33,7 +34,6 @@ export class TextInput {
       "relative",
       "z-10"
     );
-
     const submitTextInput = () => {
       if (this.textField.value) {
         textInputClickout.classList.toggle("hidden");
@@ -42,8 +42,20 @@ export class TextInput {
         this.textField.focus();
       }
     };
+    const toggleTextInput = () => {
+      this.container.classList.toggle("hidden");
+      this.container.classList.remove("ring-2");
+      textInputClickout.classList.toggle("hidden");
+    };
     submitIcon.onclick = submitTextInput;
-    textInputClickout.onclick = submitTextInput;
+    // Close text input field by clicking outside or hitting esc
+    textInputClickout.onclick = toggleTextInput;
+    textInputClickout.addEventListener("keypress", (event) => {
+      if (event.key === "Escape" || event.key === "Esc") {
+        console.log("DEBUG: " + event.key);
+        toggleTextInput();
+      }
+    });
     this.textField.addEventListener("keypress", (event) => {
       if (event.key === "Enter") {
         submitTextInput();

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -20,21 +20,7 @@ export class TextInput {
     label.innerHTML = `${title}:`;
     const submitIcon = makeIcon("check");
     const textInputClickout = makeClickout();
-    textInputClickout.classList.add("absolute", "z-10");
     textInputClickout.classList.toggle("hidden");
-
-    this.container.className =
-      "font-inter font-medium text-12 text-black px-2 py-1 rounded-md ring-2 ring-offset-1 ring-red inline-block flex-auto items-center space-x-2";
-    this.textField.className =
-      "ring-0 border-0 outline-0 rounded-sm relative px-1 min-w-[150px] z-40";
-    this.textField.setAttribute("size", "10");
-    submitIcon.classList.add(
-      "text-black",
-      "hover:text-green",
-      "relative",
-      "z-40"
-    );
-    label.classList.add("relative", "z-40");
 
     const submitTextInput = () => {
       if (this.textField.value) {
@@ -84,10 +70,23 @@ export class TextInput {
 
     document.addEventListener("keydown", handleEsc);
 
-    this.container.append(label);
-    this.container.appendChild(this.textField);
+    this.container.className = "inline-block flex-auto items-center";
+    var textInputContainer = document.createElement("div");
+    textInputContainer.className =
+      "font-inter font-medium text-12 text-black px-2 py-1 rounded-md ring-2 ring-offset-1 ring-red inline-block flex-auto items-center space-x-2 relative z-40";
+    this.textField.className =
+      "ring-0 border-0 outline-0 rounded-sm px-1 min-w-[150px]";
+    this.textField.setAttribute("size", "10");
+    submitIcon.classList.add("text-black", "hover:text-green");
+
+    textInputContainer.append(label);
+    textInputContainer.appendChild(this.textField);
+    textInputContainer.appendChild(submitIcon);
+    // this.container.append(label);
+    // this.container.appendChild(this.textField);
+    this.container.append(textInputContainer);
     this.container.append(this.datalist);
-    this.container.appendChild(submitIcon);
+    // this.container.appendChild(submitIcon);
     this.container.appendChild(textInputClickout);
     // wait for browser to render element before setting focus
     window.setTimeout(() => this.textField.focus(), 0);

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -1,6 +1,5 @@
 import { makeClickout, makeIcon } from "../util/html-utils";
 import { get } from "../util/requests";
-import { toggleLegend } from "./legend";
 
 export class TextInput {
   private container: HTMLElement;
@@ -42,19 +41,8 @@ export class TextInput {
         this.textField.focus();
       }
     };
-    const toggleTextInput = () => {
-      this.container.classList.toggle("hidden");
-      this.container.classList.remove("ring-2");
-      textInputClickout.classList.toggle("hidden");
-    };
+
     submitIcon.onclick = submitTextInput;
-    // Close text input field by clicking outside or hitting esc
-    textInputClickout.onclick = toggleTextInput;
-    textInputClickout.addEventListener("keypress", (event) => {
-      if (event.key === "Escape" || event.key === "Esc") {
-        toggleTextInput();
-      }
-    });
     this.textField.addEventListener("keypress", (event) => {
       if (event.key === "Enter") {
         submitTextInput();
@@ -75,19 +63,26 @@ export class TextInput {
         this.loadAutocomplete(queryUrl);
       }
     });
+    // close text input field by clicking outside or hitting esc
+    textInputClickout.onclick = () => {
+      this.container.remove();
+    };
 
-    // hide text input box by hitting Esc
-    document.addEventListener("keydown", (event) => {
-      // only remove the text input box in question if it is not already hidden
-      if (event.key === "Esc" || event.key === "Escape") {
-        const containerHidden = this.container.classList.contains("hidden");
-        const textFieldHidden = this.textField.classList.contains("hidden");
-        // hide text input fields' corresponding elements if they are visible
-        if (!containerHidden && !textFieldHidden) {
-          toggleTextInput();
+    document.addEventListener(
+      "keydown",
+      (event) => {
+        // only remove the text input box in question if it is not already hidden
+        if (event.key === "Esc" || event.key === "Escape") {
+          const containerHidden = this.container.classList.contains("hidden");
+          const textFieldHidden = this.textField.classList.contains("hidden");
+          // remove text input field corresponding elements if they are visible
+          if (!containerHidden && !textFieldHidden) {
+            this.container.remove();
+          }
         }
-      }
-    });
+      },
+      { once: true } // remove event listener immediately once event occurs
+    );
 
     this.container.append(label);
     this.container.appendChild(this.textField);

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -70,10 +70,11 @@ export class TextInput {
 
     document.addEventListener("keydown", handleEsc);
 
-    this.container.className = "inline-block flex-auto items-center";
+    this.container.className =
+      "inline-block flex-auto rounded-md ring-red ring-2 ring-offset-1";
     var textInputContainer = document.createElement("div");
     textInputContainer.className =
-      "font-inter font-medium text-12 text-black px-2 py-1 rounded-md ring-2 ring-offset-1 ring-red inline-block flex-auto items-center space-x-2 relative z-40";
+      "font-inter font-medium text-12 text-black px-2 py-1 inline-block space-x-2 relative z-40";
     this.textField.className =
       "ring-0 border-0 outline-0 rounded-sm px-1 min-w-[150px]";
     this.textField.setAttribute("size", "10");
@@ -81,9 +82,9 @@ export class TextInput {
 
     textInputContainer.append(label);
     textInputContainer.appendChild(this.textField);
+    textInputContainer.append(this.datalist);
     textInputContainer.appendChild(submitIcon);
-    this.container.append(textInputContainer);
-    this.container.append(this.datalist);
+    this.container.appendChild(textInputContainer);
     this.container.appendChild(textInputClickout);
     // wait for browser to render element before setting focus
     window.setTimeout(() => this.textField.focus(), 0);

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -52,7 +52,6 @@ export class TextInput {
     textInputClickout.onclick = toggleTextInput;
     textInputClickout.addEventListener("keypress", (event) => {
       if (event.key === "Escape" || event.key === "Esc") {
-        console.log("DEBUG: " + event.key);
         toggleTextInput();
       }
     });
@@ -74,6 +73,19 @@ export class TextInput {
       } else {
         // value was user-typed, display autcomplete suggestion list
         this.loadAutocomplete(queryUrl);
+      }
+    });
+
+    // hide text input box by hitting Esc
+    document.addEventListener("keydown", (event) => {
+      // only remove the text input box in question if it is not already hidden
+      if (event.key === "Esc" || event.key === "Escape") {
+        const containerHidden = this.container.classList.contains("hidden");
+        const textFieldHidden = this.textField.classList.contains("hidden");
+        // hide text input fields' corresponding elements if they are visible
+        if (!containerHidden && !textFieldHidden) {
+          toggleTextInput();
+        }
       }
     });
 

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -82,11 +82,8 @@ export class TextInput {
     textInputContainer.append(label);
     textInputContainer.appendChild(this.textField);
     textInputContainer.appendChild(submitIcon);
-    // this.container.append(label);
-    // this.container.appendChild(this.textField);
     this.container.append(textInputContainer);
     this.container.append(this.datalist);
-    // this.container.appendChild(submitIcon);
     this.container.appendChild(textInputClickout);
     // wait for browser to render element before setting focus
     window.setTimeout(() => this.textField.focus(), 0);

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -20,7 +20,7 @@ export class TextInput {
     label.innerHTML = `${title}:`;
     const submitIcon = makeIcon("check");
     const textInputClickout = makeClickout();
-    textInputClickout.classList.add("z-10");
+    textInputClickout.classList.add("absolute", "z-10");
     textInputClickout.classList.toggle("hidden");
 
     this.container.className =
@@ -34,6 +34,7 @@ export class TextInput {
       "relative",
       "z-40"
     );
+    label.classList.add("relative", "z-40");
 
     const submitTextInput = () => {
       if (this.textField.value) {

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -30,25 +30,19 @@ export class TextInput {
     submitIcon.classList.add("text-black", "hover:text-green", "relative");
     const submitTextInput = () => {
       if (this.textField.value) {
-        // can submit entered text
         onClose(this);
-        // remove event listeners for submission and esc
-        this.textField.removeEventListener("keypress", handleSubmit);
-        textInputClickout.remove(); // remove clickout
         document.removeEventListener("keydown", handleEsc);
       } else {
         this.textField.focus();
       }
     };
 
-    var handleSubmit = (event: KeyboardEvent) => {
+    submitIcon.onclick = submitTextInput;
+    this.textField.addEventListener("keypress", (event) => {
       if (event.key === "Enter") {
         submitTextInput();
       }
-    };
-
-    submitIcon.onclick = submitTextInput;
-    this.textField.addEventListener("keypress", handleSubmit);
+    });
 
     this.textField.addEventListener("input", () => {
       this.styleValidity();
@@ -71,14 +65,12 @@ export class TextInput {
       if (event.key === "Esc" || event.key === "Escape") {
         // remove text input field corresponding elements if they are visible
         this.container.remove();
-        this.textField.removeEventListener("keypress", handleSubmit);
         document.removeEventListener("keydown", handleEsc);
       }
     };
     // close text input field by clicking outside or hitting esc
     textInputClickout.onclick = () => {
       this.container.remove();
-      this.textField.removeEventListener("keypress", handleSubmit);
       document.removeEventListener("keydown", handleEsc);
     };
 

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -20,14 +20,21 @@ export class TextInput {
     label.innerHTML = `${title}:`;
     const submitIcon = makeIcon("check");
     const textInputClickout = makeClickout();
+    textInputClickout.classList.add("z-10");
     textInputClickout.classList.toggle("hidden");
 
     this.container.className =
       "font-inter font-medium text-12 text-black px-2 py-1 rounded-md ring-2 ring-offset-1 ring-red inline-block flex-auto items-center space-x-2";
     this.textField.className =
-      "ring-0 border-0 outline-0 rounded-sm relative px-1 min-w-[150px]";
+      "ring-0 border-0 outline-0 rounded-sm relative px-1 min-w-[150px] z-40";
     this.textField.setAttribute("size", "10");
-    submitIcon.classList.add("text-black", "hover:text-green", "relative");
+    submitIcon.classList.add(
+      "text-black",
+      "hover:text-green",
+      "relative",
+      "z-40"
+    );
+
     const submitTextInput = () => {
       if (this.textField.value) {
         onClose(this);

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -30,19 +30,26 @@ export class TextInput {
     submitIcon.classList.add("text-black", "hover:text-green", "relative");
     const submitTextInput = () => {
       if (this.textField.value) {
-        textInputClickout.classList.toggle("hidden");
+        // can submit entered text
         onClose(this);
+        // remove event listeners for submission and esc
+        this.textField.removeEventListener("keypress", handleSubmit);
+        textInputClickout.remove(); // remove clickout
+        document.removeEventListener("keydown", handleEsc);
       } else {
         this.textField.focus();
       }
     };
 
-    submitIcon.onclick = submitTextInput;
-    this.textField.addEventListener("keypress", (event) => {
+    var handleSubmit = (event: KeyboardEvent) => {
       if (event.key === "Enter") {
         submitTextInput();
       }
-    });
+    };
+
+    submitIcon.onclick = submitTextInput;
+    this.textField.addEventListener("keypress", handleSubmit);
+
     this.textField.addEventListener("input", () => {
       this.styleValidity();
       this.textField.setAttribute(
@@ -59,21 +66,23 @@ export class TextInput {
       }
     });
 
-    var handleKeydown = (event: KeyboardEvent) => {
+    var handleEsc = (event: KeyboardEvent) => {
       // only remove the text input box in question if it is not already hidden
       if (event.key === "Esc" || event.key === "Escape") {
         // remove text input field corresponding elements if they are visible
         this.container.remove();
-        document.removeEventListener("keydown", handleKeydown);
+        this.textField.removeEventListener("keypress", handleSubmit);
+        document.removeEventListener("keydown", handleEsc);
       }
     };
     // close text input field by clicking outside or hitting esc
     textInputClickout.onclick = () => {
       this.container.remove();
-      document.removeEventListener("keydown", handleKeydown);
+      this.textField.removeEventListener("keypress", handleSubmit);
+      document.removeEventListener("keydown", handleEsc);
     };
 
-    document.addEventListener("keydown", handleKeydown);
+    document.addEventListener("keydown", handleEsc);
 
     this.container.append(label);
     this.container.appendChild(this.textField);

--- a/ts/component/text-input.ts
+++ b/ts/component/text-input.ts
@@ -58,26 +58,22 @@ export class TextInput {
         this.loadAutocomplete(queryUrl);
       }
     });
+
+    var handleKeydown = (event: KeyboardEvent) => {
+      // only remove the text input box in question if it is not already hidden
+      if (event.key === "Esc" || event.key === "Escape") {
+        // remove text input field corresponding elements if they are visible
+        this.container.remove();
+        document.removeEventListener("keydown", handleKeydown);
+      }
+    };
     // close text input field by clicking outside or hitting esc
     textInputClickout.onclick = () => {
       this.container.remove();
+      document.removeEventListener("keydown", handleKeydown);
     };
 
-    document.addEventListener(
-      "keydown",
-      (event) => {
-        // only remove the text input box in question if it is not already hidden
-        if (event.key === "Esc" || event.key === "Escape") {
-          const containerHidden = this.container.classList.contains("hidden");
-          const textFieldHidden = this.textField.classList.contains("hidden");
-          // remove text input field corresponding elements if they are visible
-          if (!containerHidden && !textFieldHidden) {
-            this.container.remove();
-          }
-        }
-      },
-      { once: true } // remove event listener immediately once event occurs
-    );
+    document.addEventListener("keydown", handleKeydown);
 
     this.container.append(label);
     this.container.appendChild(this.textField);

--- a/ts/util/html-utils.ts
+++ b/ts/util/html-utils.ts
@@ -98,7 +98,7 @@ export function addIconButton(container: HTMLElement, iconName: string) {
 export function makeClickout() {
   const clickout = document.createElement("button");
   clickout.className =
-    "bg-transparent fixed inset-0 w-full h-full cursor-default hidden z-10";
+    "bg-transparent fixed inset-0 w-full h-full cursor-default hidden";
   return clickout;
 }
 

--- a/ts/util/html-utils.ts
+++ b/ts/util/html-utils.ts
@@ -98,7 +98,7 @@ export function addIconButton(container: HTMLElement, iconName: string) {
 export function makeClickout() {
   const clickout = document.createElement("button");
   clickout.className =
-    "bg-transparent fixed inset-0 w-full h-full cursor-default hidden";
+    "bg-transparent fixed inset-0 w-full h-full cursor-default hidden z-10";
   return clickout;
 }
 


### PR DESCRIPTION
As per [GLT-3744](https://jira.oicr.on.ca/browse/GLT-3744)

Because most of the dropdown menu buttons employ the same parent class, an extra param (displayTemporary) was added in order to specify whether a button should be removed if an event calls for it, or if they are "permanent" buttons. E.g. The "Items per page" would be a permanent button (should not be removed by hitting esc or clicking out), but buttons created from selecting a filter option are temporary (can be removed by hitting esc or clicking out).