### PR TITLE
[GLT-3852] updated to support gsi-qc-etl changes for supplemental samples

### DIFF
--- a/changes/change_supplementalSamples.md
+++ b/changes/change_supplementalSamples.md
@@ -1,0 +1,2 @@
+Cases now belong to a single requisition, and will include samples from other requisitions only
+when explicitly added as supplemental samples

--- a/src/main/java/ca/on/oicr/gsi/dimsum/CaseLoader.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/CaseLoader.java
@@ -436,6 +436,7 @@ public class CaseLoader {
       throws DataParseException, IOException {
     return loadFromJsonArrayFile(fileReader, json -> {
       String donorId = parseString(json, "donor_id", true);
+      Long requisitionId = parseLong(json, "requisition_id", true);
       Long assayId = parseLong(json, "assay_id", true);
       return new Case.Builder()
           .id(parseString(json, "id", true))
@@ -448,7 +449,7 @@ public class CaseLoader {
           .stopped(parseBoolean(json, "stopped"))
           .receipts(parseIdsAndGet(json, "receipt_ids", JsonNode::asText, samplesById))
           .tests(parseTests(json, "assay_tests", samplesById))
-          .requisitions(parseIdsAndGet(json, "requisition_ids", JsonNode::asLong, requisitionsById))
+          .requisition(requisitionsById.get(requisitionId))
           .build();
     });
   }

--- a/src/main/java/ca/on/oicr/gsi/dimsum/controller/mvc/RequisitionController.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/controller/mvc/RequisitionController.java
@@ -36,8 +36,7 @@ public class RequisitionController {
       throw new NotFoundException(
           String.format("No data found for requisition: %s", requisitionId));
     }
-    Requisition requisition = cases.get(0).getRequisitions().stream()
-        .filter(req -> req.getId() == Long.parseLong(requisitionId)).findAny().orElseThrow();
+    Requisition requisition = cases.get(0).getRequisition();
 
     model.put("title", String.format("%s Requisition Details", requisition.getName()));
     model.put("titleLink", makeMisoRequisitionUrl(requisitionId));

--- a/src/main/java/ca/on/oicr/gsi/dimsum/data/Case.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/data/Case.java
@@ -29,7 +29,7 @@ public class Case {
   private final List<Sample> receipts;
   private final LocalDate startDate;
   private final List<Test> tests;
-  private final List<Requisition> requisitions;
+  private final Requisition requisition;
   private final LocalDate latestActivityDate;
 
   private Case(Builder builder) {
@@ -44,7 +44,7 @@ public class Case {
     this.stopped = builder.stopped;
     this.receipts = unmodifiableList(builder.receipts);
     this.tests = unmodifiableList(builder.tests);
-    this.requisitions = unmodifiableList(builder.requisitions);
+    this.requisition = builder.requisition;
     this.startDate = builder.receipts.stream()
         .filter(sample -> !"R".equals(sample.getTissueType()))
         .map(Sample::getCreatedDate)
@@ -52,7 +52,7 @@ public class Case {
     this.latestActivityDate = Stream
         .of(receipts.stream().map(Sample::getLatestActivityDate),
             tests.stream().map(Test::getLatestActivityDate),
-            requisitions.stream().map(Requisition::getLatestActivityDate))
+            Stream.of(requisition.getLatestActivityDate()))
         .flatMap(Function.identity()).filter(Objects::nonNull).max(LocalDate::compareTo)
         .orElse(null);
   }
@@ -106,8 +106,8 @@ public class Case {
     return tests;
   }
 
-  public List<Requisition> getRequisitions() {
-    return requisitions;
+  public Requisition getRequisition() {
+    return requisition;
   }
 
   public LocalDate getLatestActivityDate() {
@@ -126,7 +126,7 @@ public class Case {
     private boolean stopped;
     private List<Sample> receipts;
     private List<Test> tests;
-    private List<Requisition> requisitions;
+    private Requisition requisition;
 
     public Builder id(String id) {
       this.id = id;
@@ -178,8 +178,8 @@ public class Case {
       return this;
     }
 
-    public Builder requisitions(List<Requisition> requisitions) {
-      this.requisitions = requisitions;
+    public Builder requisition(Requisition requisition) {
+      this.requisition = requisition;
       return this;
     }
 

--- a/src/main/java/ca/on/oicr/gsi/dimsum/service/CaseService.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/service/CaseService.java
@@ -235,7 +235,7 @@ public class CaseService {
     List<Case> cases = getCases(baseFilter);
     TableData<Requisition> data = new TableData<>();
     data.setTotalCount(
-        cases.stream().flatMap(kase -> kase.getRequisitions().stream()).distinct().count());
+        cases.stream().map(Case::getRequisition).distinct().count());
     List<Requisition> requisitions = filterRequisitions(cases, filters).distinct().toList();
     data.setFilteredCount(requisitions.size());
     data.setItems(requisitions.stream()
@@ -366,7 +366,7 @@ public class CaseService {
 
   private Stream<Requisition> filterRequisitions(List<Case> cases, Collection<CaseFilter> filters) {
     Stream<Requisition> stream = filterCases(cases, filters)
-        .flatMap(kase -> kase.getRequisitions().stream());
+        .map(Case::getRequisition);
     if (filters != null && !filters.isEmpty()) {
       Map<CaseFilterKey, Predicate<Requisition>> filterMap =
           buildFilterMap(filters, CaseFilter::requisitionPredicate);

--- a/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseFilterKey.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseFilterKey.java
@@ -40,10 +40,8 @@ public enum CaseFilterKey {
       .anyMatch(project -> project.getPipeline().equals(string))),
   PROJECT(string -> kase -> kase.getProjects().stream()
       .anyMatch(project -> project.getName().equalsIgnoreCase(string))),
-  REQUISITION(string -> kase -> kase.getRequisitions().stream()
-      .anyMatch(req -> req.getName().toLowerCase().startsWith(string.toLowerCase()))),
-  REQUISITION_ID(string -> kase -> kase.getRequisitions().stream()
-      .anyMatch(req -> req.getId() == Long.parseLong(string)));
+  REQUISITION(string -> kase -> kase.getRequisition().getName().toLowerCase().startsWith(string.toLowerCase())),
+  REQUISITION_ID(string -> kase -> kase.getRequisition().getId() == Long.parseLong(string));
   // @formatter:on
 
   private final Function<String, Predicate<Case>> create;

--- a/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/PendingState.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/PendingState.java
@@ -234,7 +234,7 @@ public enum PendingState {
     @Override
     protected boolean qualifyCase(Case kase) {
       return kase.getTests().stream().allMatch(Helpers.isCompleted(Test::getFullDepthSequencings))
-          && kase.getRequisitions().stream().anyMatch(this::qualifyRequisition);
+          && this.qualifyRequisition(kase.getRequisition());
     }
 
     @Override
@@ -246,7 +246,7 @@ public enum PendingState {
     @Override
     protected boolean qualifyCase(Case kase) {
       return Helpers.isCompletedRequisitionQc(kase, Requisition::getInformaticsReviews)
-          && kase.getRequisitions().stream().anyMatch(this::qualifyRequisition);
+          && this.qualifyRequisition(kase.getRequisition());
     }
 
     @Override
@@ -258,7 +258,7 @@ public enum PendingState {
     @Override
     protected boolean qualifyCase(Case kase) {
       return Helpers.isCompletedRequisitionQc(kase, Requisition::getDraftReports)
-          && kase.getRequisitions().stream().anyMatch(this::qualifyRequisition);
+          && this.qualifyRequisition(kase.getRequisition());
     }
 
     @Override
@@ -393,9 +393,8 @@ public enum PendingState {
 
     public static boolean isCompletedRequisitionQc(Case kase,
         Function<Requisition, List<RequisitionQc>> getQcs) {
-      return kase.getRequisitions().stream()
-          .allMatch(requisition -> getQcs.apply(requisition).stream()
-              .anyMatch(qc -> qc.isQcPassed()));
+      return getQcs.apply(kase.getRequisition()).stream()
+          .anyMatch(qc -> qc.isQcPassed());
     }
   }
 

--- a/src/test/java/ca/on/oicr/gsi/dimsum/service/CaseServiceTest.java
+++ b/src/test/java/ca/on/oicr/gsi/dimsum/service/CaseServiceTest.java
@@ -30,8 +30,8 @@ public class CaseServiceTest {
     sut = new CaseService(null);
     caseData = mock(CaseData.class);
     when(caseData.getCases()).thenReturn(new ArrayList<>());
-    addCase(caseData, 1);
-    addCase(caseData, 2);
+    addCase(caseData, 1, 1);
+    addCase(caseData, 2, 2);
     sut.setCaseData(caseData);
   }
 
@@ -54,7 +54,7 @@ public class CaseServiceTest {
   @org.junit.jupiter.api.Test
   public void testGetReceiptsDistinct() {
     // Add duplicates and ensure they get removed from results
-    addCase(caseData, 1);
+    addCase(caseData, 1, 1);
     TableData<Sample> data = sut.getReceipts(10, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1N-A1", "1N-A2", "2N-A1", "2N-A2");
   }
@@ -69,7 +69,7 @@ public class CaseServiceTest {
   @org.junit.jupiter.api.Test
   public void testGetExtractionsDistinct() {
     // Add duplicates and ensure they get removed from results
-    addCase(caseData, 1);
+    addCase(caseData, 1, 1);
     TableData<Sample> data = sut.getExtractions(20, 1, SampleSort.NAME, true, null, null);
     assertContainsSamples(data, "1A-B1", "1A-B2", "1B-B1", "1B-B2", "2A-B1", "2A-B2", "2B-B1",
         "2B-B2");
@@ -111,16 +111,16 @@ public class CaseServiceTest {
   public void testGetRequisitions() {
     TableData<Requisition> data =
         sut.getRequisitions(20, 1, RequisitionSort.NAME, true, null, null);
-    assertContainsRequisitions(data, "REQ_1-1", "REQ_1-2", "REQ_2-1", "REQ_2-2");
+    assertContainsRequisitions(data, "REQ_1", "REQ_2");
   }
 
   @org.junit.jupiter.api.Test
   public void testGetRequisitionsDistinct() {
     // Add duplicates and ensure they get removed from results
-    addCase(caseData, 1);
+    addCase(caseData, 1, 1);
     TableData<Requisition> data =
         sut.getRequisitions(20, 1, RequisitionSort.NAME, true, null, null);
-    assertContainsRequisitions(data, "REQ_1-1", "REQ_1-2", "REQ_2-1", "REQ_2-2");
+    assertContainsRequisitions(data, "REQ_1", "REQ_2");
   }
 
   private void assertContainsRequisitions(TableData<Requisition> data, String... requisitionNames) {
@@ -135,7 +135,7 @@ public class CaseServiceTest {
     }
   }
 
-  private void addCase(CaseData data, int caseNumber) {
+  private void addCase(CaseData data, int caseNumber, int requisitionNumber) {
     Case kase = mock(Case.class);
     when(kase.getLatestActivityDate()).thenReturn(LocalDate.now().minusDays(caseNumber));
     when(kase.getReceipts()).thenReturn(new ArrayList<>());
@@ -144,9 +144,7 @@ public class CaseServiceTest {
     when(kase.getTests()).thenReturn(new ArrayList<>());
     addTest(kase, caseNumber, "A");
     addTest(kase, caseNumber, "B");
-    when(kase.getRequisitions()).thenReturn(new ArrayList<>());
-    addRequisition(kase, caseNumber, 1);
-    addRequisition(kase, caseNumber, 2);
+    when(kase.getRequisition()).thenReturn(makeRequisition(requisitionNumber));
     data.getCases().add(kase);
   }
 
@@ -183,13 +181,13 @@ public class CaseServiceTest {
         .createdDate(LocalDate.now()).build());
   }
 
-  private void addRequisition(Case kase, int caseNumber, int requisitionNumber) {
+  private Requisition makeRequisition(int requisitionNumber) {
     // Not using mocks because we're kind-of testing hashcode for distinct filters here too
-    kase.getRequisitions().add(new Requisition.Builder()
-        .id(caseNumber * 100 + requisitionNumber)
-        .name(String.format("REQ_%d-%d", caseNumber, requisitionNumber))
+    return new Requisition.Builder()
+        .id(requisitionNumber)
+        .name(String.format("REQ_%d", requisitionNumber))
         .assayId(2L)
-        .build());
+        .build();
   }
 
 }

--- a/src/test/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseFilterTest.java
+++ b/src/test/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseFilterTest.java
@@ -527,8 +527,8 @@ public class CaseFilterTest {
       List<Long> expectedRequisitionIds) {
     List<Requisition> requisitions = cases.stream()
         .filter(filter.casePredicate())
-        .flatMap(kase -> kase.getRequisitions().stream()
-            .filter(filter.requisitionPredicate()))
+        .map(kase -> kase.getRequisition())
+        .filter(filter.requisitionPredicate())
         .toList();
     for (Long id : expectedRequisitionIds) {
       assertTrue(
@@ -625,7 +625,7 @@ public class CaseFilterTest {
     // Case is pending draft report
     Case kase = makeCase("PRO4_0001", "Single Test", "PRO4", "REQ04", caseNumber);
     addTest(kase, caseNumber, 1, "Test", true, true, true, true);
-    Requisition requisition = kase.getRequisitions().get(0);
+    Requisition requisition = kase.getRequisition();
     addRequisitionQc(requisition.getInformaticsReviews(), true);
     return kase;
   }
@@ -635,7 +635,7 @@ public class CaseFilterTest {
     // Case is pending final report
     Case kase = makeCase("PRO5_0001", "Single Test", "PRO5", "REQ04", caseNumber);
     addTest(kase, caseNumber, 1, "Test", true, true, true, true);
-    Requisition requisition = kase.getRequisitions().get(0);
+    Requisition requisition = kase.getRequisition();
     addRequisitionQc(requisition.getInformaticsReviews(), true);
     addRequisitionQc(requisition.getDraftReports(), true);
     return kase;
@@ -811,7 +811,6 @@ public class CaseFilterTest {
     String receiptSampleId = makeSampleId(caseNumber, 0, MetricCategory.RECEIPT, 1);
     addSample(kase.getReceipts(), receiptSampleId, true, "Good");
     when(kase.getTests()).thenReturn(new ArrayList<>());
-    when(kase.getRequisitions()).thenReturn(new ArrayList<>());
     addRequisition(kase, caseNumber, requisitionName);
     return kase;
   }
@@ -834,7 +833,7 @@ public class CaseFilterTest {
     when(requisition.getInformaticsReviews()).thenReturn(new ArrayList<>());
     when(requisition.getDraftReports()).thenReturn(new ArrayList<>());
     when(requisition.getFinalReports()).thenReturn(new ArrayList<>());
-    kase.getRequisitions().add(requisition);
+    when(kase.getRequisition()).thenReturn(requisition);
     return requisition;
   }
 

--- a/src/test/resources/testdata/cases.json
+++ b/src/test/resources/testdata/cases.json
@@ -58,7 +58,7 @@
         "full_depth_sequencing_ids": ["5476_1_LDI73621", "5540_1_LDI73621"]
       }
     ],
-    "requisition_ids": [512],
+    "requisition_id": 512,
     "stopped": false
   }
 ]


### PR DESCRIPTION
There is really nothing to do with supplemental samples here, except that cases now belong to a single requisition instead of multiple