### PR TITLE
[GLT-3866] fix determining case start date

### DIFF
--- a/changes/change_caseStartDate.md
+++ b/changes/change_caseStartDate.md
@@ -1,0 +1,2 @@
+Case start date is now determined based on samples in the case's primary requisition, and excludes
+supplemental samples

--- a/src/main/java/ca/on/oicr/gsi/dimsum/data/Case.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/data/Case.java
@@ -46,7 +46,7 @@ public class Case {
     this.tests = unmodifiableList(builder.tests);
     this.requisition = builder.requisition;
     this.startDate = builder.receipts.stream()
-        .filter(sample -> !"R".equals(sample.getTissueType()))
+        .filter(sample -> sample.getRequisitionId().longValue() == builder.requisition.getId())
         .map(Sample::getCreatedDate)
         .min(LocalDate::compareTo).orElse(null);
     this.latestActivityDate = Stream


### PR DESCRIPTION
It's now possible for cases to be _only_ tissue type "R," so the old start date calculation doesn't work anymore. Now that cases have a primary requisition, this method makes more sense anyway