### PR TITLE
[GLT-4051] added deliverable-type-specific filter options

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "name": "Debug local Dimsum",
       "request": "attach",
       "hostName": "localhost",
-      "port": 8083
+      "port": 8000
     }
   ]
 }

--- a/changes/add_deliverableTypeFilters.md
+++ b/changes/add_deliverableTypeFilters.md
@@ -1,0 +1,1 @@
+Separate options for Data Release and Clinical Report in Pending, Completed, and Incomplete filters

--- a/changes/fix_pendingWork_previousSkipped.md
+++ b/changes/fix_pendingWork_previousSkipped.md
@@ -1,0 +1,1 @@
+The pending work icon was not appearing when the previous step was "N/A"

--- a/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseFilterKey.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseFilterKey.java
@@ -66,7 +66,8 @@ public enum CaseFilterKey {
   },
   INCOMPLETE(string -> {
     CompletedGate gate = getGate(string);
-    return gate.predicate().negate(); // Negate the completed condition
+    Predicate<Case> applicable = x -> gate.isApplicable(x);
+    return applicable.and(gate.predicate().negate()); // Negate the completed condition
 }) {
     @Override
     public Function<String, Predicate<Test>> testPredicate() {

--- a/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/PendingState.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/service/filtering/PendingState.java
@@ -238,6 +238,22 @@ public enum PendingState {
           && !CompletedGate.ANALYSIS_REVIEW.qualifyCase(kase);
     }
   },
+  ANALYSIS_REVIEW_DATA_RELEASE("Analysis Review - Data Release", true) {
+    @Override
+    public boolean qualifyCase(Case kase) {
+      return CompletedGate.FULL_DEPTH_SEQUENCING.qualifyCase(kase)
+          && CompletedGate.ANALYSIS_REVIEW_DATA_RELEASE.isApplicable(kase)
+          && !CompletedGate.ANALYSIS_REVIEW_DATA_RELEASE.qualifyCase(kase);
+    }
+  },
+  ANALYSIS_REVIEW_CLINICAL_REPORT("Analysis Review - Clinical Report", true) {
+    @Override
+    public boolean qualifyCase(Case kase) {
+      return CompletedGate.FULL_DEPTH_SEQUENCING.qualifyCase(kase)
+          && CompletedGate.ANALYSIS_REVIEW_CLINICAL_REPORT.isApplicable(kase)
+          && !CompletedGate.ANALYSIS_REVIEW_CLINICAL_REPORT.qualifyCase(kase);
+    }
+  },
   RELEASE_APPROVAL("Release Approval", false) {
 
     @Override
@@ -246,11 +262,43 @@ public enum PendingState {
           && !CompletedGate.RELEASE_APPROVAL.qualifyCase(kase);
     }
   },
+  RELEASE_APPROVAL_DATA_RELEASE("Release Approval - Data Release", true) {
+    @Override
+    public boolean qualifyCase(Case kase) {
+      return (kase.isStopped() || CompletedGate.ANALYSIS_REVIEW_DATA_RELEASE.qualifyCase(kase))
+          && CompletedGate.RELEASE_APPROVAL_DATA_RELEASE.isApplicable(kase)
+          && !CompletedGate.RELEASE_APPROVAL_DATA_RELEASE.qualifyCase(kase);
+    }
+  },
+  RELEASE_APPROVAL_CLINICAL_REPORT("Release Approval - Clinical Report", true) {
+    @Override
+    public boolean qualifyCase(Case kase) {
+      return (kase.isStopped() || CompletedGate.ANALYSIS_REVIEW_CLINICAL_REPORT.qualifyCase(kase))
+          && CompletedGate.RELEASE_APPROVAL_CLINICAL_REPORT.isApplicable(kase)
+          && !CompletedGate.RELEASE_APPROVAL_CLINICAL_REPORT.qualifyCase(kase);
+    }
+  },
   RELEASE("Release", false) {
     @Override
     public boolean qualifyCase(Case kase) {
       return CompletedGate.RELEASE_APPROVAL.qualifyCase(kase)
           && !CompletedGate.RELEASE.qualifyCase(kase);
+    }
+  },
+  RELEASE_DATA_RELEASE("Release - Data Release", false) {
+    @Override
+    public boolean qualifyCase(Case kase) {
+      return CompletedGate.RELEASE_APPROVAL_DATA_RELEASE.qualifyCase(kase)
+          && CompletedGate.RELEASE_DATA_RELEASE.isApplicable(kase)
+          && !CompletedGate.RELEASE_DATA_RELEASE.qualifyCase(kase);
+    }
+  },
+  RELEASE_CLINICAL_REPORT("Release - Clinical Report", false) {
+    @Override
+    public boolean qualifyCase(Case kase) {
+      return CompletedGate.RELEASE_APPROVAL_CLINICAL_REPORT.qualifyCase(kase)
+          && CompletedGate.RELEASE_CLINICAL_REPORT.isApplicable(kase)
+          && !CompletedGate.RELEASE_CLINICAL_REPORT.qualifyCase(kase);
     }
   };
   // @formatter:on

--- a/src/main/java/ca/on/oicr/gsi/dimsum/util/SampleUtils.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/util/SampleUtils.java
@@ -15,8 +15,14 @@ public class SampleUtils {
       sample -> isPassed(sample) || isPendingQc(sample) || isPendingDataReview(sample);
 
   public static boolean isPassed(Sample sample) {
-    return isTrue(sample.getQcPassed())
-        && (sample.getRun() == null || isTrue(sample.getDataReviewPassed()));
+    if (!isTrue(sample.getQcPassed())) {
+      return false;
+    }
+    if (sample.getRun() == null) {
+      return true;
+    }
+    return isTrue(sample.getQcPassed()) && isTrue(sample.getDataReviewPassed())
+        && isTrue(sample.getRun().getQcPassed()) && isTrue(sample.getRun().getDataReviewPassed());
   }
 
   private static boolean isTrue(Boolean value) {
@@ -24,12 +30,15 @@ public class SampleUtils {
   }
 
   public static boolean isPendingQc(Sample sample) {
-    return sample.getQcPassed() == null && !isTopUpRequired(sample);
+    return sample.getQcUser() == null
+        || (sample.getRun() != null && sample.getRun().getQcPassed() == null);
   }
 
   public static boolean isPendingDataReview(Sample sample) {
-    return sample.getQcUser() != null && sample.getRun() != null
-        && sample.getDataReviewPassed() == null;
+    return sample.getRun() != null
+        && ((sample.getQcUser() != null && sample.getDataReviewPassed() == null)
+            || (sample.getRun().getQcPassed() != null
+                && sample.getRun().getDataReviewPassed() == null));
   }
 
   public static boolean isTopUpRequired(Sample sample) {

--- a/src/test/java/ca/on/oicr/gsi/dimsum/MockCase.java
+++ b/src/test/java/ca/on/oicr/gsi/dimsum/MockCase.java
@@ -31,7 +31,7 @@ public class MockCase {
           makeCase6(), makeCase7(), makeCase8(), makeCase9(), makeCase10(), makeCase11(),
           makeCase12(), makeCase13(), makeCase14(), makeCase15(), makeCase16(), makeCase17(),
           makeCase18(), makeCase19(), makeCase20(), makeCase21(), makeCase22(), makeCase23(),
-          makeCase24());
+          makeCase24(), makeCase25(), makeCase26(), makeCase27(), makeCase28());
 
   private static Case makeCase0() {
     final int caseNumber = 0;
@@ -305,6 +305,58 @@ public class MockCase {
     return kase;
   }
 
+  private static Case makeCase25() {
+    final int caseNumber = 25;
+    // Case is pending analysis review - clinical report
+    Case kase = makeCase("PRO25_0001", "Single Test", "PRO25", "REQ25", caseNumber);
+    addTest(kase, caseNumber, 1, "Test", "WG", true, true, true, true);
+    markAnalysisReview(kase.getDeliverables().get(0), true);
+    markReleaseApproval(kase.getDeliverables().get(0), true);
+    markRelease(kase.getDeliverables().get(0).getReleases().get(0), true);
+    addDeliverable(kase, DeliverableType.CLINICAL_REPORT, "Clinical Report");
+    return kase;
+  }
+
+  private static Case makeCase26() {
+    final int caseNumber = 26;
+    // Case is pending release approval - clinical report
+    Case kase = makeCase("PRO26_0001", "Single Test", "PRO26", "REQ26", caseNumber);
+    addTest(kase, caseNumber, 1, "Test", "WG", true, true, true, true);
+    markAnalysisReview(kase.getDeliverables().get(0), true);
+    markReleaseApproval(kase.getDeliverables().get(0), true);
+    markRelease(kase.getDeliverables().get(0).getReleases().get(0), true);
+    CaseDeliverable deliverable =
+        addDeliverable(kase, DeliverableType.CLINICAL_REPORT, "Clinical Report");
+    markAnalysisReview(deliverable, true);
+    return kase;
+  }
+
+  private static Case makeCase27() {
+    final int caseNumber = 27;
+    // Case is pending release - clinical report
+    Case kase = makeCase("PRO27_0001", "Single Test", "PRO27", "REQ27", caseNumber);
+    addTest(kase, caseNumber, 1, "Test", "WG", true, true, true, true);
+    markAnalysisReview(kase.getDeliverables().get(0), true);
+    markReleaseApproval(kase.getDeliverables().get(0), true);
+    markRelease(kase.getDeliverables().get(0).getReleases().get(0), true);
+    CaseDeliverable deliverable =
+        addDeliverable(kase, DeliverableType.CLINICAL_REPORT, "Clinical Report");
+    markAnalysisReview(deliverable, true);
+    markReleaseApproval(deliverable, true);
+    return kase;
+  }
+
+  private static Case makeCase28() {
+    final int caseNumber = 28;
+    // Case is completed
+    Case kase = makeCase("PRO28_0001", "Single Test", "PRO28", "REQ28", caseNumber);
+    addTest(kase, caseNumber, 1, "Test", "WG", true, true, true, true);
+    markAnalysisReview(kase.getDeliverables().get(0), true);
+    markReleaseApproval(kase.getDeliverables().get(0), true);
+    markRelease(kase.getDeliverables().get(0).getReleases().get(0), true);
+    return kase;
+  }
+
   private static Case makeCase(String donorName, String assayName, String projectName,
       String requisitionName, int caseNumber) {
     Case kase = mock(Case.class);
@@ -321,17 +373,25 @@ public class MockCase {
     addSample(kase.getReceipts(), receiptSampleId, true, "Good");
     when(kase.getTests()).thenReturn(new ArrayList<>());
     addRequisition(kase, caseNumber, requisitionName);
-
     when(kase.getDeliverables()).thenReturn(new ArrayList<>());
-    CaseDeliverable deliverable = mock(CaseDeliverable.class);
-    when(deliverable.getDeliverableType()).thenReturn(DeliverableType.DATA_RELEASE);
-    when(deliverable.getReleases()).thenReturn(new ArrayList<>());
-    CaseRelease release = mock(CaseRelease.class);
-    when(release.getDeliverable()).thenReturn("Full Pipeline");
-    deliverable.getReleases().add(release);
-    kase.getDeliverables().add(deliverable);
-
+    addDeliverable(kase, DeliverableType.DATA_RELEASE, "Full Pipeline");
     return kase;
+  }
+
+  private static CaseDeliverable addDeliverable(Case kase, DeliverableType deliverableType,
+      String deliverableName) {
+    CaseDeliverable deliverable = kase.getDeliverables().stream()
+        .filter(x -> x.getDeliverableType() == deliverableType).findFirst().orElse(null);
+    if (deliverable == null) {
+      deliverable = mock(CaseDeliverable.class);
+      when(deliverable.getDeliverableType()).thenReturn(deliverableType);
+      when(deliverable.getReleases()).thenReturn(new ArrayList<>());
+      kase.getDeliverables().add(deliverable);
+    }
+    CaseRelease release = mock(CaseRelease.class);
+    when(release.getDeliverable()).thenReturn(deliverableName);
+    deliverable.getReleases().add(release);
+    return deliverable;
   }
 
   private static String makeSampleId(int caseNumber, int testNumber, MetricCategory gate,
@@ -365,6 +425,12 @@ public class MockCase {
     when(deliverable.getReleaseApprovalQcPassed()).thenReturn(qcPassed);
     when(deliverable.getReleaseApprovalQcUser()).thenReturn("User");
     when(deliverable.getReleaseApprovalQcDate()).thenReturn(LocalDate.now());
+  }
+
+  private static void markRelease(CaseRelease release, Boolean qcPassed) {
+    when(release.getQcPassed()).thenReturn(qcPassed);
+    when(release.getQcUser()).thenReturn("User");
+    when(release.getQcDate()).thenReturn(LocalDate.now());
   }
 
   private static ca.on.oicr.gsi.cardea.data.Test addTest(Case kase, int caseNumber, int testNumber,
@@ -428,6 +494,12 @@ public class MockCase {
 
   private static Sample addRunLibrary(List<Sample> gateItems, String id, Boolean qcPassed,
       String qcReason, Boolean dataReviewPassed) {
+    return addRunLibrary(gateItems, id, qcPassed, qcReason, dataReviewPassed, qcPassed,
+        dataReviewPassed);
+  }
+
+  private static Sample addRunLibrary(List<Sample> gateItems, String id, Boolean qcPassed,
+      String qcReason, Boolean dataReviewPassed, Boolean runQcPassed, Boolean runDataReviewPassed) {
     Sample sample = addSample(gateItems, id, qcPassed, qcReason);
     Run run = mock(Run.class);
     when(sample.getRun()).thenReturn(run);
@@ -435,6 +507,16 @@ public class MockCase {
     if (dataReviewPassed != null) {
       when(sample.getDataReviewUser()).thenReturn("User");
       when(sample.getDataReviewDate()).thenReturn(LocalDate.now());
+    }
+    if (runQcPassed != null) {
+      when(run.getQcPassed()).thenReturn(runQcPassed);
+      when(run.getQcUser()).thenReturn("User");
+      when(run.getQcDate()).thenReturn(LocalDate.now());
+    }
+    if (runDataReviewPassed != null) {
+      when(run.getDataReviewPassed()).thenReturn(runDataReviewPassed);
+      when(run.getDataReviewUser()).thenReturn("User");
+      when(run.getDataReviewDate()).thenReturn(LocalDate.now());
     }
     return sample;
   }

--- a/src/test/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseFilterTest.java
+++ b/src/test/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseFilterTest.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import ca.on.oicr.gsi.cardea.data.Case;
 import ca.on.oicr.gsi.cardea.data.MetricCategory;
 import ca.on.oicr.gsi.cardea.data.Sample;
@@ -439,23 +440,68 @@ public class CaseFilterTest {
   }
 
   @org.junit.jupiter.api.Test
-  public void testPendingAnalysisFilter() {
+  public void testPendingAnalysisReviewFilter() {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.PENDING, PendingState.ANALYSIS_REVIEW.getLabel());
+    testFilterCases(filter, Arrays.asList(4, 25));
+  }
+
+  @org.junit.jupiter.api.Test
+  public void testPendingAnalysisReviewDataReleaseFilter() {
+    CaseFilter filter =
+        new CaseFilter(CaseFilterKey.PENDING, PendingState.ANALYSIS_REVIEW_DATA_RELEASE.getLabel());
     testFilterCases(filter, Arrays.asList(4));
+  }
+
+  @org.junit.jupiter.api.Test
+  public void testPendingAnalysisReviewClinicalReportFilter() {
+    CaseFilter filter =
+        new CaseFilter(CaseFilterKey.PENDING,
+            PendingState.ANALYSIS_REVIEW_CLINICAL_REPORT.getLabel());
+    testFilterCases(filter, Arrays.asList(25));
   }
 
   @org.junit.jupiter.api.Test
   public void testPendingReleaseApprovalFilter() {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.PENDING, PendingState.RELEASE_APPROVAL.getLabel());
+    testFilterCases(filter, Arrays.asList(5, 26));
+  }
+
+  @org.junit.jupiter.api.Test
+  public void testPendingReleaseApprovalDataReleaseFilter() {
+    CaseFilter filter =
+        new CaseFilter(CaseFilterKey.PENDING,
+            PendingState.RELEASE_APPROVAL_DATA_RELEASE.getLabel());
     testFilterCases(filter, Arrays.asList(5));
+  }
+
+  @org.junit.jupiter.api.Test
+  public void testPendingReleaseApprovalClinicalReportFilter() {
+    CaseFilter filter =
+        new CaseFilter(CaseFilterKey.PENDING,
+            PendingState.RELEASE_APPROVAL_CLINICAL_REPORT.getLabel());
+    testFilterCases(filter, Arrays.asList(26));
   }
 
   @org.junit.jupiter.api.Test
   public void testPendingReleaseFilter() {
     CaseFilter filter = new CaseFilter(CaseFilterKey.PENDING, PendingState.RELEASE.getLabel());
+    testFilterCases(filter, Arrays.asList(6, 27));
+  }
+
+  @org.junit.jupiter.api.Test
+  public void testPendingReleaseDataReleaseFilter() {
+    CaseFilter filter =
+        new CaseFilter(CaseFilterKey.PENDING, PendingState.RELEASE_DATA_RELEASE.getLabel());
     testFilterCases(filter, Arrays.asList(6));
+  }
+
+  @org.junit.jupiter.api.Test
+  public void testPendingReleaseClinicalReportFilter() {
+    CaseFilter filter =
+        new CaseFilter(CaseFilterKey.PENDING, PendingState.RELEASE_CLINICAL_REPORT.getLabel());
+    testFilterCases(filter, Arrays.asList(27));
   }
 
   @org.junit.jupiter.api.Test
@@ -463,7 +509,7 @@ public class CaseFilterTest {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.COMPLETED, CompletedGate.RECEIPT.getLabel());
     testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-        17, 18, 19, 20, 21, 23, 24));
+        17, 18, 19, 20, 21, 23, 24, 25, 26, 27, 28));
   }
 
   @org.junit.jupiter.api.Test
@@ -509,7 +555,11 @@ public class CaseFilterTest {
         makeTestGroupId(20, 1),
         makeTestGroupId(21, 1),
         makeTestGroupId(23, 1),
-        makeTestGroupId(24, 1)));
+        makeTestGroupId(24, 1),
+        makeTestGroupId(25, 1),
+        makeTestGroupId(26, 1),
+        makeTestGroupId(27, 1),
+        makeTestGroupId(28, 1)));
   }
 
   @org.junit.jupiter.api.Test
@@ -542,7 +592,11 @@ public class CaseFilterTest {
             makeSampleId(20, 0, MetricCategory.RECEIPT, 1),
             makeSampleId(21, 0, MetricCategory.RECEIPT, 1),
             makeSampleId(23, 0, MetricCategory.RECEIPT, 1),
-            makeSampleId(24, 0, MetricCategory.RECEIPT, 1)));
+            makeSampleId(24, 0, MetricCategory.RECEIPT, 1),
+            makeSampleId(25, 0, MetricCategory.RECEIPT, 1),
+            makeSampleId(26, 0, MetricCategory.RECEIPT, 1),
+            makeSampleId(27, 0, MetricCategory.RECEIPT, 1),
+            makeSampleId(28, 0, MetricCategory.RECEIPT, 1)));
   }
 
 
@@ -551,7 +605,7 @@ public class CaseFilterTest {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.COMPLETED, CompletedGate.EXTRACTION.getLabel());
     testFilterCases(filter, Arrays.asList(1, 2, 3, 4, 5, 6, 9, 10, 11, 12, 13, 14, 15, 16,
-        17, 18, 19, 20, 21));
+        17, 18, 19, 20, 21, 25, 26, 27, 28));
   }
 
   @org.junit.jupiter.api.Test
@@ -590,7 +644,11 @@ public class CaseFilterTest {
         makeTestGroupId(18, 1),
         makeTestGroupId(19, 1),
         makeTestGroupId(20, 1),
-        makeTestGroupId(21, 1)));
+        makeTestGroupId(21, 1),
+        makeTestGroupId(25, 1),
+        makeTestGroupId(26, 1),
+        makeTestGroupId(27, 1),
+        makeTestGroupId(28, 1)));
   }
 
   @org.junit.jupiter.api.Test
@@ -622,7 +680,11 @@ public class CaseFilterTest {
         makeSampleId(18, 1, MetricCategory.EXTRACTION, 1),
         makeSampleId(19, 1, MetricCategory.EXTRACTION, 1),
         makeSampleId(20, 1, MetricCategory.EXTRACTION, 1),
-        makeSampleId(21, 1, MetricCategory.EXTRACTION, 1)));
+        makeSampleId(21, 1, MetricCategory.EXTRACTION, 1),
+        makeSampleId(25, 1, MetricCategory.EXTRACTION, 1),
+        makeSampleId(26, 1, MetricCategory.EXTRACTION, 1),
+        makeSampleId(27, 1, MetricCategory.EXTRACTION, 1),
+        makeSampleId(28, 1, MetricCategory.EXTRACTION, 1)));
   }
 
   @org.junit.jupiter.api.Test
@@ -630,7 +692,7 @@ public class CaseFilterTest {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.COMPLETED, CompletedGate.LIBRARY_PREPARATION.getLabel());
     testFilterCases(filter, Arrays.asList(2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16,
-        17, 18, 19, 21));
+        17, 18, 19, 21, 25, 26, 27, 28));
   }
 
   @org.junit.jupiter.api.Test
@@ -663,7 +725,11 @@ public class CaseFilterTest {
         makeTestGroupId(17, 1),
         makeTestGroupId(18, 1),
         makeTestGroupId(19, 1),
-        makeTestGroupId(21, 1)));
+        makeTestGroupId(21, 1),
+        makeTestGroupId(25, 1),
+        makeTestGroupId(26, 1),
+        makeTestGroupId(27, 1),
+        makeTestGroupId(28, 1)));
   }
 
   @org.junit.jupiter.api.Test
@@ -689,7 +755,11 @@ public class CaseFilterTest {
         makeSampleId(17, 1, MetricCategory.LIBRARY_PREP, 1),
         makeSampleId(18, 1, MetricCategory.LIBRARY_PREP, 1),
         makeSampleId(19, 1, MetricCategory.LIBRARY_PREP, 1),
-        makeSampleId(21, 1, MetricCategory.LIBRARY_PREP, 1)));
+        makeSampleId(21, 1, MetricCategory.LIBRARY_PREP, 1),
+        makeSampleId(25, 1, MetricCategory.LIBRARY_PREP, 1),
+        makeSampleId(26, 1, MetricCategory.LIBRARY_PREP, 1),
+        makeSampleId(27, 1, MetricCategory.LIBRARY_PREP, 1),
+        makeSampleId(28, 1, MetricCategory.LIBRARY_PREP, 1)));
   }
 
   @org.junit.jupiter.api.Test
@@ -697,7 +767,7 @@ public class CaseFilterTest {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.COMPLETED,
             CompletedGate.LIBRARY_QUALIFICATION.getLabel());
-    testFilterCases(filter, Arrays.asList(3, 4, 5, 6, 16, 17, 18, 19));
+    testFilterCases(filter, Arrays.asList(3, 4, 5, 6, 16, 17, 18, 19, 25, 26, 27, 28));
   }
 
   @org.junit.jupiter.api.Test
@@ -724,7 +794,11 @@ public class CaseFilterTest {
         makeTestGroupId(16, 1),
         makeTestGroupId(17, 1),
         makeTestGroupId(18, 1),
-        makeTestGroupId(19, 1)));
+        makeTestGroupId(19, 1),
+        makeTestGroupId(25, 1),
+        makeTestGroupId(26, 1),
+        makeTestGroupId(27, 1),
+        makeTestGroupId(28, 1)));
   }
 
   @org.junit.jupiter.api.Test
@@ -742,7 +816,11 @@ public class CaseFilterTest {
         makeSampleId(16, 1, MetricCategory.LIBRARY_QUALIFICATION, 1),
         makeSampleId(17, 1, MetricCategory.LIBRARY_QUALIFICATION, 1),
         makeSampleId(18, 1, MetricCategory.LIBRARY_QUALIFICATION, 1),
-        makeSampleId(19, 1, MetricCategory.LIBRARY_QUALIFICATION, 1)));
+        makeSampleId(19, 1, MetricCategory.LIBRARY_QUALIFICATION, 1),
+        makeSampleId(25, 1, MetricCategory.LIBRARY_QUALIFICATION, 1),
+        makeSampleId(26, 1, MetricCategory.LIBRARY_QUALIFICATION, 1),
+        makeSampleId(27, 1, MetricCategory.LIBRARY_QUALIFICATION, 1),
+        makeSampleId(28, 1, MetricCategory.LIBRARY_QUALIFICATION, 1)));
   }
 
   @org.junit.jupiter.api.Test
@@ -750,7 +828,7 @@ public class CaseFilterTest {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.COMPLETED,
             CompletedGate.FULL_DEPTH_SEQUENCING.getLabel());
-    testFilterCases(filter, Arrays.asList(4, 5, 6));
+    testFilterCases(filter, Arrays.asList(4, 5, 6, 25, 26, 27, 28));
   }
 
   @org.junit.jupiter.api.Test
@@ -766,13 +844,16 @@ public class CaseFilterTest {
   @org.junit.jupiter.api.Test
   public void testCompletedFullDepthTestFilter() {
     CaseFilter filter =
-        new CaseFilter(CaseFilterKey.COMPLETED,
-            CompletedGate.FULL_DEPTH_SEQUENCING.getLabel());
+        new CaseFilter(CaseFilterKey.COMPLETED, CompletedGate.FULL_DEPTH_SEQUENCING.getLabel());
     testFilterTests(filter, Arrays.asList(
         makeTestGroupId(4, 1),
         makeTestGroupId(5, 1),
         makeTestGroupId(6, 1),
-        makeTestGroupId(6, 2)));
+        makeTestGroupId(6, 2),
+        makeTestGroupId(25, 1),
+        makeTestGroupId(26, 1),
+        makeTestGroupId(27, 1),
+        makeTestGroupId(28, 1)));
   }
 
   @org.junit.jupiter.api.Test
@@ -784,24 +865,26 @@ public class CaseFilterTest {
         makeSampleId(4, 1, MetricCategory.FULL_DEPTH_SEQUENCING, 1),
         makeSampleId(5, 1, MetricCategory.FULL_DEPTH_SEQUENCING, 1),
         makeSampleId(6, 1, MetricCategory.FULL_DEPTH_SEQUENCING, 1),
-        makeSampleId(6, 2, MetricCategory.FULL_DEPTH_SEQUENCING, 1)));
+        makeSampleId(6, 2, MetricCategory.FULL_DEPTH_SEQUENCING, 1),
+        makeSampleId(25, 1, MetricCategory.FULL_DEPTH_SEQUENCING, 1),
+        makeSampleId(26, 1, MetricCategory.FULL_DEPTH_SEQUENCING, 1),
+        makeSampleId(27, 1, MetricCategory.FULL_DEPTH_SEQUENCING, 1),
+        makeSampleId(28, 1, MetricCategory.FULL_DEPTH_SEQUENCING, 1)));
   }
 
   @org.junit.jupiter.api.Test
-  public void testCompletedAnalysisFilter() {
+  public void testCompletedAnalysisReviewFilter() {
     CaseFilter filter =
-        new CaseFilter(CaseFilterKey.COMPLETED,
-            CompletedGate.ANALYSIS_REVIEW.getLabel());
-    testFilterCases(filter, Arrays.asList(5, 6));
+        new CaseFilter(CaseFilterKey.COMPLETED, CompletedGate.ANALYSIS_REVIEW.getLabel());
+    testFilterCases(filter, Arrays.asList(5, 6, 26, 27, 28));
   }
 
   @org.junit.jupiter.api.Test
-  public void testIncompleteAnalysisFilter() {
+  public void testIncompleteAnalysisReviewFilter() {
     CaseFilter filter =
-        new CaseFilter(CaseFilterKey.INCOMPLETE,
-            CompletedGate.ANALYSIS_REVIEW.getLabel());
-    testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 7, 8, 9,
-        10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24));
+        new CaseFilter(CaseFilterKey.INCOMPLETE, CompletedGate.ANALYSIS_REVIEW.getLabel());
+    testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+        18, 19, 20, 21, 22, 23, 24, 25));
   }
 
   @org.junit.jupiter.api.Test
@@ -809,16 +892,15 @@ public class CaseFilterTest {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.COMPLETED,
             CompletedGate.RELEASE_APPROVAL.getLabel());
-    testFilterCases(filter, Arrays.asList(6));
+    testFilterCases(filter, Arrays.asList(6, 27, 28));
   }
 
   @org.junit.jupiter.api.Test
   public void testIncompleteReleaseApprovalFilter() {
     CaseFilter filter =
-        new CaseFilter(CaseFilterKey.INCOMPLETE,
-            CompletedGate.RELEASE_APPROVAL.getLabel());
-    testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 5, 7, 8, 9,
-        10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24));
+        new CaseFilter(CaseFilterKey.INCOMPLETE, CompletedGate.RELEASE_APPROVAL.getLabel());
+    testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+        18, 19, 20, 21, 22, 23, 24, 25, 26));
   }
 
   @org.junit.jupiter.api.Test
@@ -826,7 +908,7 @@ public class CaseFilterTest {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.COMPLETED,
             CompletedGate.RELEASE.getLabel());
-    testFilterCases(filter, Collections.emptyList());
+    testFilterCases(filter, Collections.singletonList(28));
   }
 
   @org.junit.jupiter.api.Test
@@ -834,8 +916,8 @@ public class CaseFilterTest {
     CaseFilter filter =
         new CaseFilter(CaseFilterKey.INCOMPLETE,
             CompletedGate.RELEASE.getLabel());
-    testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-        10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24));
+    testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+        17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27));
   }
 
   @org.junit.jupiter.api.Test
@@ -848,7 +930,7 @@ public class CaseFilterTest {
   public void testNonStoppedCaseFilter() {
     CaseFilter filter = new CaseFilter(CaseFilterKey.STOPPED, "No");
     testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-        17, 18, 19, 20, 21, 22, 24));
+        17, 18, 19, 20, 21, 22, 24, 25, 26, 27, 28));
   }
 
   @org.junit.jupiter.api.Test
@@ -861,7 +943,7 @@ public class CaseFilterTest {
   public void testNonPausedCaseFilter() {
     CaseFilter filter = new CaseFilter(CaseFilterKey.PAUSED, "No");
     testFilterCases(filter, Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-        17, 18, 19, 20, 21, 22, 23));
+        17, 18, 19, 20, 21, 22, 23, 25, 26, 27, 28));
   }
 
   private static List<Case> getCasesFiltered(CaseFilter filter) {
@@ -874,7 +956,9 @@ public class CaseFilterTest {
       assertTrue(filtered.contains(cases.get(caseNumber)),
           String.format("Case #%d included", caseNumber));
     }
-    assertEquals(expectedCases.size(), filtered.size(), "Case count");
+    assertEquals(expectedCases.size(), filtered.size(),
+        "Case count (%s)".formatted(filtered.stream()
+            .map(kase -> String.valueOf(cases.indexOf(kase))).collect(Collectors.joining(", "))));
   }
 
   private static void testFilterTests(CaseFilter filter, List<String> expectedTestGroupIds) {

--- a/src/test/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseSortTest.java
+++ b/src/test/java/ca/on/oicr/gsi/dimsum/service/filtering/CaseSortTest.java
@@ -320,6 +320,7 @@ public class CaseSortTest {
 
   private static Sample mockPassedSample() {
     Sample sample = mock(Sample.class);
+    when(sample.getQcUser()).thenReturn("User");
     when(sample.getQcDate()).thenReturn(LocalDate.now());
     when(sample.getQcPassed()).thenReturn(true);
     return sample;

--- a/src/test/java/ca/on/oicr/gsi/dimsum/service/filtering/SampleSortTest.java
+++ b/src/test/java/ca/on/oicr/gsi/dimsum/service/filtering/SampleSortTest.java
@@ -86,27 +86,37 @@ public class SampleSortTest {
         when(sample.getQcReason()).thenReturn(null);
         when(sample.getRun()).thenReturn(null);
         break;
-      case 1: // Pending Data Review
-        when(sample.getQcPassed()).thenReturn(true);
-        when(sample.getDataReviewPassed()).thenReturn(null);
-        when(sample.getQcUser()).thenReturn("someUser");
-        when(sample.getRun()).thenReturn(mock(Run.class));
-        break;
-      case 2: // Top-Up Required
-        when(sample.getQcPassed()).thenReturn(true);
-        when(sample.getQcReason()).thenReturn(SampleUtils.TOP_UP_REASON);
-        break;
-
-      case 3: // Passed
+      case 1: {// Pending Data Review
         when(sample.getQcPassed()).thenReturn(true);
         when(sample.getDataReviewPassed()).thenReturn(true);
-        when(sample.getRun()).thenReturn(mock(Run.class));
+        when(sample.getQcUser()).thenReturn("user1");
+        when(sample.getQcReason()).thenReturn(null);
+        Run run = mock(Run.class);
+        when(run.getQcPassed()).thenReturn(true);
+        when(run.getDataReviewPassed()).thenReturn(null);
+        when(sample.getRun()).thenReturn(run);
         break;
-      case 4: // Other
+      }
+      case 2: {// Top-Up Required
+        when(sample.getQcPassed()).thenReturn(null);
+        when(sample.getDataReviewPassed()).thenReturn(true);
+        when(sample.getQcUser()).thenReturn("user2");
+        when(sample.getQcReason()).thenReturn(SampleUtils.TOP_UP_REASON);
+        Run run = mock(Run.class);
+        when(run.getQcPassed()).thenReturn(true);
+        when(run.getDataReviewPassed()).thenReturn(true);
+        when(sample.getRun()).thenReturn(run);
+        break;
+      }
+      case 3: // Passed
+        when(sample.getQcPassed()).thenReturn(true);
+        when(sample.getQcUser()).thenReturn("user3");
+        when(sample.getQcReason()).thenReturn(null);
+        break;
+      case 4: // Other (failed)
         when(sample.getQcPassed()).thenReturn(false);
-        when(sample.getDataReviewPassed()).thenReturn(false);
-        when(sample.getQcReason()).thenReturn("Some other reason");
-        when(sample.getRun()).thenReturn(null);
+        when(sample.getQcUser()).thenReturn("user4");
+        when(sample.getQcReason()).thenReturn(null);
         break;
     }
     return sample;
@@ -129,38 +139,40 @@ public class SampleSortTest {
     switch (sampleNumber) {
       case 0: // Pending QC
         when(sample.getQcPassed()).thenReturn(null);
-        when(sample.getDataReviewPassed()).thenReturn(null);
         when(sample.getQcUser()).thenReturn(null);
         when(sample.getQcReason()).thenReturn(null);
-        when(sample.getRun()).thenReturn(null);
         break;
-      case 1: // Pending Data Review
+      case 1: {// Pending Data Review
         when(sample.getQcPassed()).thenReturn(true);
         when(sample.getDataReviewPassed()).thenReturn(true);
         when(sample.getQcUser()).thenReturn("user1");
         when(sample.getQcReason()).thenReturn(null);
-        when(sample.getRun()).thenReturn(mock(Run.class));
+        Run run = mock(Run.class);
+        when(run.getQcPassed()).thenReturn(true);
+        when(run.getDataReviewPassed()).thenReturn(null);
+        when(sample.getRun()).thenReturn(run);
         break;
-      case 2: // Top-Up Required
-        when(sample.getQcPassed()).thenReturn(false);
-        when(sample.getDataReviewPassed()).thenReturn(false);
+      }
+      case 2: {// Top-Up Required
+        when(sample.getQcPassed()).thenReturn(null);
+        when(sample.getDataReviewPassed()).thenReturn(true);
         when(sample.getQcUser()).thenReturn("user2");
         when(sample.getQcReason()).thenReturn(SampleUtils.TOP_UP_REASON);
-        when(sample.getRun()).thenReturn(mock(Run.class));
+        Run run = mock(Run.class);
+        when(run.getQcPassed()).thenReturn(true);
+        when(run.getDataReviewPassed()).thenReturn(true);
+        when(sample.getRun()).thenReturn(run);
         break;
+      }
       case 3: // Passed
         when(sample.getQcPassed()).thenReturn(true);
-        when(sample.getDataReviewPassed()).thenReturn(null);
         when(sample.getQcUser()).thenReturn("user3");
         when(sample.getQcReason()).thenReturn(null);
-        when(sample.getRun()).thenReturn(mock(Run.class));
         break;
-      case 4: // Other
+      case 4: // Other (failed)
         when(sample.getQcPassed()).thenReturn(false);
-        when(sample.getDataReviewPassed()).thenReturn(true);
         when(sample.getQcUser()).thenReturn("user4");
         when(sample.getQcReason()).thenReturn(null);
-        when(sample.getRun()).thenReturn(mock(Run.class));
         break;
     }
     return sample;


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4051

- [x] Includes a change file

Note the PR target is the other deliverables branch that is approved but not yet merged, and depends on Cardea changes that are also not yet merged/released