### PR TITLE
[GLT-4121] fixed highlighting of run-libraries that failed via run QC

### DIFF
--- a/changes/fix_highlight.md
+++ b/changes/fix_highlight.md
@@ -1,0 +1,2 @@
+Library qualification and full-depth sequencing would be highlighted as incomplete if an item had
+failed run QC with run-library QC left incomplete. These should be considered completed (failed)


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4121

- [x] Includes a change file
- [x] Updated tests (or n/a)
- [x] Updated documentation (or n/a)
- [x] Discussed with CGI (or n/a; see release procedure on wiki for applicability)
