### PR TITLE
[GLT-4314] Simplified SAML2 internal configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 2. Copy [example-application.properties](example-application.properties) into the `config`
    directory and rename it to `application.properties`
 3. Are you enabling SAML authentication?
-   * If yes:
+   - If yes:
      1. add the IdP certificate to your `config` directory
      2. generate/add your SP key and certificate to the `config` directory. An example using `openssl`:
      
@@ -23,8 +23,37 @@
 
      3. fill out the SAML properties in `application.properties`, including paths to the
         above-mentioned certificates/key
-   * If no, add the following line to `application.properties` to disable authentication:
+   - If no, add the following line to `application.properties` to disable authentication:
      `spring.profiles.active=noauth`
+
+## Identity Provider Configuration
+
+Dimsum information you'll likely need to configure on your IdP:
+
+- **Entity ID**: `<base-url>/saml2/service-provider-metadata/dimsum` (this is also the URL of the service
+provider metadata if you need to download the XML)
+- **POST Logout URL for single logout**: `<base-url>/logout/saml2/slo`
+
+### Example Keycloak Client Configuration
+
+- **Client type**: SAML
+- **Client ID**: `<base-url>/saml2/service-provider-metadata/dimsum`
+- **Name**: Dimsum
+- **Always display in UI**: On
+- **Root URL**: `http://localhost:8081`
+- **Valid redirect URIs**: `/*`
+
+**Advanced settings (after saving)**
+
+- **Logout Service POST Binding URL**: `<base-url>/logout/saml2/slo`
+
+**Certificates**
+
+To add the SP certificate to Keycloak, go to __Client__ -> __Keys__ -> __Import Key__. Choose
+Archive format "Certificate PEM" and add the SP certificate generated above.
+
+To get the IdP certificate from Keycloak, go to __Realm settings__ -> __Keys__ > __RS256__ ->
+__Certificate__. Save the text to a file.
 
 ## Build/Run
 

--- a/src/main/java/ca/on/oicr/gsi/dimsum/SecurityConfiguration.java
+++ b/src/main/java/ca/on/oicr/gsi/dimsum/SecurityConfiguration.java
@@ -1,27 +1,10 @@
 package ca.on.oicr.gsi.dimsum;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.security.interfaces.RSAPrivateKey;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.saml2.core.Saml2X509Credential;
-import org.springframework.security.saml2.provider.service.metadata.OpenSaml4MetadataResolver;
-import org.springframework.security.saml2.provider.service.registration.InMemoryRelyingPartyRegistrationRepository;
-import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
-import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
-import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrations;
-import org.springframework.security.saml2.provider.service.web.DefaultRelyingPartyRegistrationResolver;
-import org.springframework.security.saml2.provider.service.web.RelyingPartyRegistrationResolver;
-import org.springframework.security.saml2.provider.service.web.Saml2MetadataFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import jakarta.servlet.DispatcherType;
 
@@ -44,58 +27,9 @@ public class SecurityConfiguration {
         .requestMatchers(LOGIN_URL).permitAll()
         .anyRequest().authenticated())
         .saml2Login(saml -> saml.loginPage(LOGIN_URL))
+        .saml2Metadata(Customizer.withDefaults())
         .saml2Logout(Customizer.withDefaults());
     return http.build();
-  }
-
-  @Bean
-  public RelyingPartyRegistrationRepository repository(
-      @Value("${saml.idpmetadataurl}") String metadataUrl, @Value("${baseurl}") String baseUrl,
-      @Value("file://${saml.spkey}") RSAPrivateKey key,
-      @Value("${saml.spcert}") File certificateFile) {
-    Saml2X509Credential credential =
-        Saml2X509Credential.signing(key, getCertificate(certificateFile));
-    String logoutUrl = baseUrl + "/logout/saml2/slo";
-    RelyingPartyRegistration registration =
-        RelyingPartyRegistrations.fromMetadataLocation(metadataUrl)
-            .registrationId("dimsum")
-            .entityId(baseUrl + "/saml2/service-provider-metadata/dimsum")
-            .assertionConsumerServiceLocation(baseUrl + "/login/saml2/sso/dimsum")
-            .singleLogoutServiceLocation(logoutUrl)
-            .signingX509Credentials(saml2X509Credentials -> saml2X509Credentials.add(credential))
-            .build();
-    return new InMemoryRelyingPartyRegistrationRepository(registration);
-  }
-
-  private X509Certificate getCertificate(File certificateFile) {
-    try (InputStream input = new FileInputStream(certificateFile)) {
-      return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(input);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to read SP certificate");
-    }
-  }
-
-  @Bean
-  public RelyingPartyRegistrationResolver relyingPartyRegistrationResolver(
-      RelyingPartyRegistrationRepository registrations) {
-    return new DefaultRelyingPartyRegistrationResolver(registrations);
-  }
-
-  /**
-   * Add filter to publish SAML service provider metadata at the default location:
-   * /saml2/service-provider-metadata/{registrationId}
-   *
-   * @param registrations
-   * @return
-   */
-  @Bean
-  FilterRegistrationBean<Saml2MetadataFilter> metadata(
-      RelyingPartyRegistrationResolver registrations) {
-    Saml2MetadataFilter metadata =
-        new Saml2MetadataFilter(registrations, new OpenSaml4MetadataResolver());
-    FilterRegistrationBean<Saml2MetadataFilter> filter = new FilterRegistrationBean<>(metadata);
-    filter.setOrder(-101);
-    return filter;
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,8 @@ spring:
               verification.credentials:
                 - certificate-location: file://${saml.idpcertificate}
               singlesignon.url: ${saml.ssourl}
+            assertingparty:
+              metadata-uri: ${saml.idpmetadataurl}
 
 build:
   version: "@project.version@"


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4314

- [ ] Includes a change file (n/a)
- [x] Updated tests (or n/a)
- [x] Updated documentation (or n/a)
- [x] Discussed with CGI (or n/a; see release procedure on wiki for applicability)

This would probably work with our current production IdP, but there's no good way to test that and no advantage to merging it into main right now anyway. We're going to need a branch for external-dimsum at least until we're ready to switch over to Keycloak and role-based access, so I've started the `dimsum-external` branch for that.

If you'd like to test using keycloak-dev, let me know and I can help you set it up. You'll need a login for keycloak-dev with realm admin permissions, and you'll have to run Dimsum on a URL besides "http://localhost:8081" since I am using that. This doesn't need to be a URL that's visible to Keycloak, so localhost works with a different port, or you can create yourself an alias in `/etc/hosts`.