### PR TITLE
Glt 4660 fix extraction warning

### DIFF
--- a/changes/fix_external_passedOnly.md
+++ b/changes/fix_external_passedOnly.md
@@ -1,1 +1,0 @@
-The external view was showing samples that were not passed QC

--- a/ts/data/case.ts
+++ b/ts/data/case.ts
@@ -401,7 +401,7 @@ export const caseDefinition: TableDefinition<Case, Test> = {
         return getSamplePhaseHighlight(
           kase.requisition,
           test.extractions,
-          true
+          internalUser
         );
       },
     },


### PR DESCRIPTION
Jira ticket or GitHub issue: https://jira.oicr.on.ca/browse/GLT-4660

- [ ] Includes a change file (n/a)
- [x] Updated tests (or n/a)
- [x] Updated documentation (or n/a)
- [x] Discussed with CGI (or n/a; see release procedure on wiki for applicability)

Transfer is only required to show extraction complete in the internal view because the external view has no knowledge of transfers. Other parts of Dimsum already use this logic, but the warnings weren't updated.

Didn't include a change file, and deleted an existing one, because these fixes will be included in the same release that the feature is originally added.